### PR TITLE
Improved scanning

### DIFF
--- a/classes/ThemeScanner.php
+++ b/classes/ThemeScanner.php
@@ -144,48 +144,14 @@ class ThemeScanner
     }
 
     /**
-     * Process standard language filter tag (_|)
+     * Process standard language filter tags (_, __, transRaw, transRawPlural, localeUrl)
      * @param  string $content
      * @return array
      */
     protected function processStandardTags($content)
     {
-        $messages = [];
-
-        /*
-         * Regex used:
-         *
-         * {{'AJAX framework'|_}}
-         * {{\s*'([^'])+'\s*[|]\s*_\s*}}
-         *
-         * {{'AJAX framework'|_(variables)}}
-         * {{\s*'([^'])+'\s*[|]\s*_\s*\([^\)]+\)\s*}}
-         */
-
-        $quoteChar = preg_quote("'");
-
-        preg_match_all('#{{\s*'.$quoteChar.'([^'.$quoteChar.']+)'.$quoteChar.'\s*[|]\s*_\s*(?:[|].+)?}}#', $content, $match);
-        if (isset($match[1])) {
-            $messages = array_merge($messages, $match[1]);
-        }
-
-        preg_match_all('#{{\s*'.$quoteChar.'([^'.$quoteChar.']+)'.$quoteChar.'\s*[|]\s*_\s*\([^\)]+\)\s*}}#', $content, $match);
-        if (isset($match[1])) {
-            $messages = array_merge($messages, $match[1]);
-        }
-
-        $quoteChar = preg_quote('"');
-
-        preg_match_all('#{{\s*'.$quoteChar.'([^'.$quoteChar.']+)'.$quoteChar.'\s*[|]\s*_\s*(?:[|].+)?}}#', $content, $match);
-        if (isset($match[1])) {
-            $messages = array_merge($messages, $match[1]);
-        }
-
-        preg_match_all('#{{\s*'.$quoteChar.'([^'.$quoteChar.']+)'.$quoteChar.'\s*[|]\s*_\s*\([^\)]+\)\s*}}#', $content, $match);
-        if (isset($match[1])) {
-            $messages = array_merge($messages, $match[1]);
-        }
-
-        return $messages;
+        $regex = '#{{\s*(["\'])((?:(?:(?!\1)).)+)\1\s*[|]\s*(?:_{1,2}|transRaw(?:Plural)?|localeUrl)\s*(?:\((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*\))?\s*}}#';
+        preg_match_all($regex, $content, $match);
+        return $match[2] ?? [];
     }
 }

--- a/classes/ThemeScanner.php
+++ b/classes/ThemeScanner.php
@@ -150,7 +150,7 @@ class ThemeScanner
      */
     protected function processStandardTags($content)
     {
-        $regex = '#{{\s*(["\'])((?:(?:(?!\1)).)+)\1\s*[|]\s*(?:_{1,2}|transRaw(?:Plural)?|localeUrl)\s*(?:\((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*\))?\s*}}#';
+        $regex = '#{{\s*(["\'])((?:(?:(?!\1)).)+)\1\s*[|]\s*(?:_{1,2}|transRaw(?:Plural)?|localeUrl)\s*(?:\((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*\))?\s*(?:[|](?:.*))?}}#U';
         preg_match_all($regex, $content, $match);
         return $match[2] ?? [];
     }

--- a/classes/ThemeScanner.php
+++ b/classes/ThemeScanner.php
@@ -213,7 +213,7 @@ class ThemeScanner
                 && $tokens[$i+2]->typeString === 'NAME_TYPE'
                 && in_array($tokens[$i+2]->getValue(), $this->getFilters())
             ) {
-                $translatable_strings[] = $tokens[$i]->getValue();
+                $translatable_strings[] = stripslashes($tokens[$i]->getValue());
                 $i += 2;
             }
         }

--- a/tests/fixtures/classes/MessageScanner.php
+++ b/tests/fixtures/classes/MessageScanner.php
@@ -2,13 +2,10 @@
 
 use Winter\Translate\Classes\ThemeScanner;
 
-/**
- * Feature Model
- */
 class MessageScanner extends ThemeScanner
 {
-    public function doesStringMatch($string)
+    public function countMatches($string)
     {
-        return count($this->processStandardTags($string)) === 1;
+        return count($this->processStandardTags($string));
     }
 }

--- a/tests/fixtures/classes/MessageScanner.php
+++ b/tests/fixtures/classes/MessageScanner.php
@@ -4,8 +4,8 @@ use Winter\Translate\Classes\ThemeScanner;
 
 class MessageScanner extends ThemeScanner
 {
-    public function countMatches($string)
+    public function getMessages($string)
     {
-        return count($this->processStandardTags($string));
+        return $this->processStandardTags($string);
     }
 }

--- a/tests/fixtures/classes/MessageScanner.php
+++ b/tests/fixtures/classes/MessageScanner.php
@@ -1,0 +1,14 @@
+<?php namespace Winter\Translate\Tests\Fixtures\Classes;
+
+use Winter\Translate\Classes\ThemeScanner;
+
+/**
+ * Feature Model
+ */
+class MessageScanner extends ThemeScanner
+{
+    public function doesStringMatch($string)
+    {
+        return count($this->processStandardTags($string)) === 1;
+    }
+}

--- a/tests/unit/behaviors/TranslatablePageTest.php
+++ b/tests/unit/behaviors/TranslatablePageTest.php
@@ -72,45 +72,54 @@ class TranslatablePageTest extends PluginTestCase
 
         $check_strings = [
             // Should not match
-            ["hello", 0],
-            ["'hello'|_", 0],
-            ["{ 'hello'|_ }", 0],
-            ["{{ var|_ }}", 0],
-            ["{{ 'hello'|upper|_ }}", 0],
+            ["hello", []],
+            ["'hello'|_", []],
+            ["{ 'hello'|_ }", []],
+            ["{{ var|_ }}", []],
+            ["{{ 'hello'|upper|_ }}", []],
 
             // Code is syntactically wrong
-            ["{{ 'hello\"|_ }}", 0],
-            ["{{ \"hello'|_ }}", 0],
+            ["{{ 'hello\"|_ }}", []],
+            ["{{ \"hello'|_ }}", []],
 
             // Should find 1 match
-            ["{{ 'hello'|_ }}}}", 1],
-            ["{{{{ 'hello'|_ }}", 1],
-            ["{{ 'hello'|_ }}", 1],
-            ["{{ \"hello\"|_ }}", 1],
-            ["{{ \"'hello\"|_ }}", 1],
-            ["{{ '\"hello'|_ }}", 1],
-            ["{{ 'hello'|__ }}", 1],
-            ["{{ 'hello'|transRaw }}", 1],
-            ["{{ 'hello'|transRawPlural }}", 1],
-            ["{{ 'hello'|localeUrl }}", 1],
-            ["{{ 'hello'|_() }}", 1],
-            ["{{ 'hello'|_(func()) }}", 1],
-            ["{{ 'hello'|_({var: val}) }}", 1],
-            ["{{ 'hello'|_({var: func(param)}) }}", 1],
-            ["{{ 'hello'|_({var: func(nestedFunc())}) }}", 1],
-            ["{{ 'hello'|_|filter }}", 1],
-            ["{{ 'hello'|_|filter|otherfilter }}", 1],
-            ["{{ 'Apostrophe\'s'|_ }}", 1],
-            ['{{ "String with \"Double quote\""|_ }}', 1],
+            ["{{ 'hello'|_ }}}}", ['hello']],
+            ["{{{{ 'hello'|_ }}", ['hello']],
+            ["{{ 'hello'|_ }}", ['hello']],
+            ["{{ \"hello\"|_ }}", ['hello']],
+            ["{{ \"'hello\"|_ }}", ['\'hello']],
+            ["{{ '\"hello'|_ }}", ['"hello']],
+            ["{{ 'hello'|__ }}", ['hello']],
+            ["{{ 'hello'|transRaw }}", ['hello']],
+            ["{{ 'hello'|transRawPlural }}", ['hello']],
+            ["{{ 'hello'|localeUrl }}", ['hello']],
+            ["{{ 'hello'|_() }}", ['hello']],
+            ["{{ 'hello'|_(func()) }}", ['hello']],
+            ["{{ 'hello'|_({var: val}) }}", ['hello']],
+            ["{{ 'hello'|_({var: func(param)}) }}", ['hello']],
+            ["{{ 'hello'|_({var: func(nestedFunc())}) }}", ['hello']],
+            ["{{ 'hello'|_|filter }}", ['hello']],
+            ["{{ 'hello'|_|filter|otherfilter }}", ['hello']],
+            ["{{ 'Apostrophe\'s'|_ }}", ['Apostrophe\'s']],
+            ['{{ "String with \"Double quote\""|_ }}', ['String with "Double quote"']],
 
             // Should find 2 matches
-            ['{{ \'Apostrophe\\\'s\'|_ }}{{ "String with \"Double quote\""|_ }}', 2],
-            ["{{ 'hello'|_|filter|otherfilter }}{{ 'hello'|_|filter|otherfilter }}", 2],
-            ["{{ 'hello'|transRaw('nested translation'|_) }}", 2],
+            [
+                '{{ \'Apostrophe\\\'s\'|_ }}{{ "String with \"Double quote\""|_ }}',
+                ['Apostrophe\'s', 'String with "Double quote"']
+            ],
+            [
+                "{{ 'hello'|_|filter|otherfilter }}{{ 'hello'|_|filter|otherfilter }}",
+                ['hello', 'hello']
+            ],
+            [
+                "{{ 'hello'|transRaw('nested translation'|_) }}",
+                ['hello', 'nested translation']
+            ],
         ];
 
         foreach ($check_strings as $check) {
-            $this->assertEquals($scanner->countMatches($check[0]), $check[1], 'String that failed: ' . $check[0]);
+            $this->assertEquals($scanner->getMessages($check[0]), $check[1]);
         }
     }
 }

--- a/tests/unit/behaviors/TranslatablePageTest.php
+++ b/tests/unit/behaviors/TranslatablePageTest.php
@@ -6,6 +6,7 @@ use Winter\Storm\Halcyon\Model;
 use Winter\Storm\Filesystem\Filesystem;
 use Winter\Storm\Halcyon\Datasource\FileDatasource;
 use Winter\Storm\Halcyon\Datasource\Resolver;
+use Winter\Translate\Tests\Fixtures\Classes\MessageScanner;
 use Winter\Translate\Tests\Fixtures\Classes\TranslatablePage;
 
 class TranslatablePageTest extends PluginTestCase
@@ -63,5 +64,45 @@ class TranslatablePageTest extends PluginTestCase
         $page->translateContext('fr');
         $title_fr = $page->title;
         $this->assertEquals('titre francais', $title_fr);
+    }
+    
+    public function testThemeScanner()
+    {
+        $should_match = [
+            "{{ 'hello'|_ }}}}",
+            "{{{{ 'hello'|_ }}",
+            "{{ 'hello'|_ }}",
+            "{{ \"hello\"|_ }}",
+            "{{ \"'hello\"|_ }}",
+            "{{ '\"hello'|_ }}",
+            "{{ 'hello'|__ }}",
+            "{{ 'hello'|transRaw }}",
+            "{{ 'hello'|transRawPlural }}",
+            "{{ 'hello'|localeUrl }}",
+            "{{ 'hello'|_() }}",
+            "{{ 'hello'|_(func()) }}",
+            "{{ 'hello'|_({var: val}) }}",
+            "{{ 'hello'|_({var: func(param)}) }}",
+            "{{ 'hello'|_({var: func(nestedFunc())}) }}",
+        ];
+
+        $should_not_match = [
+            "{ 'hello'|_ }",
+            "{{ var|_ }}",
+            "{{ 'hello'|var|_ }}",
+            "{{ 'hello\"|_ }}",
+            "{{ \"hello'|_ }}",
+            "{{ 'hello'|_()) }}",
+        ];
+
+        $scanner = new MessageScanner();
+
+        foreach ($should_match as $string) {
+            $this->assertTrue($scanner->doesStringMatch($string));
+        }
+
+        foreach ($should_not_match as $string) {
+            $this->assertFalse($scanner->doesStringMatch($string));
+        }
     }
 }

--- a/tests/unit/behaviors/TranslatablePageTest.php
+++ b/tests/unit/behaviors/TranslatablePageTest.php
@@ -68,41 +68,42 @@ class TranslatablePageTest extends PluginTestCase
     
     public function testThemeScanner()
     {
-        $should_match = [
-            "{{ 'hello'|_ }}}}",
-            "{{{{ 'hello'|_ }}",
-            "{{ 'hello'|_ }}",
-            "{{ \"hello\"|_ }}",
-            "{{ \"'hello\"|_ }}",
-            "{{ '\"hello'|_ }}",
-            "{{ 'hello'|__ }}",
-            "{{ 'hello'|transRaw }}",
-            "{{ 'hello'|transRawPlural }}",
-            "{{ 'hello'|localeUrl }}",
-            "{{ 'hello'|_() }}",
-            "{{ 'hello'|_(func()) }}",
-            "{{ 'hello'|_({var: val}) }}",
-            "{{ 'hello'|_({var: func(param)}) }}",
-            "{{ 'hello'|_({var: func(nestedFunc())}) }}",
-        ];
-
-        $should_not_match = [
-            "{ 'hello'|_ }",
-            "{{ var|_ }}",
-            "{{ 'hello'|var|_ }}",
-            "{{ 'hello\"|_ }}",
-            "{{ \"hello'|_ }}",
-            "{{ 'hello'|_()) }}",
-        ];
-
         $scanner = new MessageScanner();
 
-        foreach ($should_match as $string) {
-            $this->assertTrue($scanner->doesStringMatch($string));
-        }
+        $check_strings = [
+            // Should not match
+            ["{ 'hello'|_ }", 0],
+            ["{{ var|_ }}", 0],
+            ["{{ 'hello'|var|_ }}", 0],
+            ["{{ 'hello\"|_ }}", 0],
+            ["{{ \"hello'|_ }}", 0],
+            ["{{ 'hello'|_()) }}", 0],
 
-        foreach ($should_not_match as $string) {
-            $this->assertFalse($scanner->doesStringMatch($string));
+            // Should find 1 match
+            ["{{ 'hello'|_ }}}}", 1],
+            ["{{{{ 'hello'|_ }}", 1],
+            ["{{ 'hello'|_ }}", 1],
+            ["{{ \"hello\"|_ }}", 1],
+            ["{{ \"'hello\"|_ }}", 1],
+            ["{{ '\"hello'|_ }}", 1],
+            ["{{ 'hello'|__ }}", 1],
+            ["{{ 'hello'|transRaw }}", 1],
+            ["{{ 'hello'|transRawPlural }}", 1],
+            ["{{ 'hello'|localeUrl }}", 1],
+            ["{{ 'hello'|_() }}", 1],
+            ["{{ 'hello'|_(func()) }}", 1],
+            ["{{ 'hello'|_({var: val}) }}", 1],
+            ["{{ 'hello'|_({var: func(param)}) }}", 1],
+            ["{{ 'hello'|_({var: func(nestedFunc())}) }}", 1],
+            ["{{ 'hello'|_|filter }}", 1],
+            ["{{ 'hello'|_|filter|otherfilter }}", 1],
+
+            // Should find 2 matches
+            ["{{ 'hello'|_|filter|otherfilter }}{{ 'hello'|_|filter|otherfilter }}", 2],
+        ];
+
+        foreach ($check_strings as $check) {
+            $this->assertEquals($scanner->countMatches($check[0]), $check[1]);
         }
     }
 }

--- a/tests/unit/behaviors/TranslatablePageTest.php
+++ b/tests/unit/behaviors/TranslatablePageTest.php
@@ -72,12 +72,15 @@ class TranslatablePageTest extends PluginTestCase
 
         $check_strings = [
             // Should not match
+            ["hello", 0],
+            ["'hello'|_", 0],
             ["{ 'hello'|_ }", 0],
             ["{{ var|_ }}", 0],
-            ["{{ 'hello'|var|_ }}", 0],
+            ["{{ 'hello'|upper|_ }}", 0],
+
+            // Code is syntactically wrong
             ["{{ 'hello\"|_ }}", 0],
             ["{{ \"hello'|_ }}", 0],
-            ["{{ 'hello'|_()) }}", 0],
 
             // Should find 1 match
             ["{{ 'hello'|_ }}}}", 1],
@@ -97,13 +100,17 @@ class TranslatablePageTest extends PluginTestCase
             ["{{ 'hello'|_({var: func(nestedFunc())}) }}", 1],
             ["{{ 'hello'|_|filter }}", 1],
             ["{{ 'hello'|_|filter|otherfilter }}", 1],
+            ["{{ 'Apostrophe\'s'|_ }}", 1],
+            ['{{ "String with \"Double quote\""|_ }}', 1],
 
             // Should find 2 matches
+            ['{{ \'Apostrophe\\\'s\'|_ }}{{ "String with \"Double quote\""|_ }}', 2],
             ["{{ 'hello'|_|filter|otherfilter }}{{ 'hello'|_|filter|otherfilter }}", 2],
+            ["{{ 'hello'|transRaw('nested translation'|_) }}", 2],
         ];
 
         foreach ($check_strings as $check) {
-            $this->assertEquals($scanner->countMatches($check[0]), $check[1]);
+            $this->assertEquals($scanner->countMatches($check[0]), $check[1], 'String that failed: ' . $check[0]);
         }
     }
 }


### PR DESCRIPTION
Proposed solution for #15 

The regular expression is a bit complicated, but to break it down into human terms, it matches matching quotes (either `'` or `"`, but not both unless the other is inside the string), followed by a pipe, followed by `_`, `__`, `transRaw`, `transRawPlural`, or `localeUrl`, optionally followed by parentheses that must match in number (i.e. `(()` would not match, but `(())` would).

I created a unit test, but the ones currently there do not pass on a fresh install:

```
$ php artisan winter:test -p Winter.Translate
Running tests for plugin: Winter.Translate
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

.EEE.......EE............                                         25 / 25 (100%)
```