### PR TITLE
Fix misnamed configuration value

### DIFF
--- a/models/Locale.php
+++ b/models/Locale.php
@@ -99,7 +99,7 @@ class Locale extends Model
             return self::$defaultLocale;
         }
 
-        if ($forceDefault = Config::get('rainlab.translate::forceDefaultLocale')) {
+        if ($forceDefault = Config::get('winter.translate::forceDefaultLocale')) {
             $locale = new self;
             $locale->name = $locale->code = $forceDefault;
             $locale->is_default = $locale->is_enabled = true;


### PR DESCRIPTION
Fixed config key in Locale model from:

$forceDefault = Config::get('rainlab.translate::forceDefaultLocale')

to: 

$forceDefault = Config::get('winter.translate::forceDefaultLocale')
