### PR TITLE
Message::firstWhere() can be NULL

### DIFF
--- a/updates/v2.1.0/migrate_message_code.php
+++ b/updates/v2.1.0/migrate_message_code.php
@@ -33,7 +33,11 @@ class MigrateMessageCode extends Migration
         ThemeScanner::scan(); // \Artisan::call('translate:scan'); doesn't works.
 
         foreach (Message::whereNull('code_pre_2_1_0')->get() as $message) {
-            if ($legacyMessage = Message::firstWhere('code_pre_2_1_0', static::makeLegacyMessageCode($message->message_data[Message::DEFAULT_LOCALE]))) {
+            $legacyMessage = Message::firstWhere(
+                'code_pre_2_1_0',
+                static::makeLegacyMessageCode($message->message_data[Message::DEFAULT_LOCALE])
+            );
+            if ($legacyMessage) {
                 $message->message_data = array_merge($legacyMessage->message_data, $message->message_data);
                 $message->save();
             }

--- a/updates/v2.1.0/migrate_message_code.php
+++ b/updates/v2.1.0/migrate_message_code.php
@@ -33,8 +33,10 @@ class MigrateMessageCode extends Migration
         ThemeScanner::scan(); // \Artisan::call('translate:scan'); doesn't works.
 
         foreach (Message::whereNull('code_pre_2_1_0')->get() as $message) {
-            $message->message_data = array_merge(Message::firstWhere('code_pre_2_1_0', static::makeLegacyMessageCode($message->message_data[Message::DEFAULT_LOCALE]))->message_data, $message->message_data);
-            $message->save();
+            if ($legacyMessage = Message::firstWhere('code_pre_2_1_0', static::makeLegacyMessageCode($message->message_data[Message::DEFAULT_LOCALE]))) {
+                $message->message_data = array_merge($legacyMessage->message_data, $message->message_data);
+                $message->save();
+            }
         }
     }
 


### PR DESCRIPTION
If `Message::firstWhere()` return `NULL` (no result), `$legacyMessage->message_data` doesn't exists and migration fail.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->