### PR TITLE
Check if cms is loaded before scanning

### DIFF
--- a/updates/v2.1.0/migrate_message_code.php
+++ b/updates/v2.1.0/migrate_message_code.php
@@ -1,5 +1,6 @@
 <?php namespace Winter\Translate\Updates;
 
+use Config;
 use Schema;
 use Str;
 use Winter\Storm\Database\Updates\Migration;
@@ -30,7 +31,9 @@ class MigrateMessageCode extends Migration
            });
         }
 
-        ThemeScanner::scan(); // \Artisan::call('translate:scan'); doesn't works.
+        if (in_array('Cms', Config::get('cms.loadModules', []))) {
+            ThemeScanner::scan();
+        }
 
         foreach (Message::whereNull('code_pre_2_1_0')->get() as $message) {
             $legacyMessage = Message::firstWhere(


### PR DESCRIPTION
This is for if someone uses Winter without the cms module loaded. If it's not loaded then scanning for themes is disregarded.