### PR TITLE
Modified isConfigured to use cache storage instead of session

### DIFF
--- a/classes/Translator.php
+++ b/classes/Translator.php
@@ -109,7 +109,7 @@ class Translator
         }
 
         if (App::hasDatabase() && Schema::hasTable('winter_translate_locales')) {
-            Cache::put(self::SESSION_CONFIGURED, true);
+            Cache::forever(self::SESSION_CONFIGURED, true);
             return $this->isConfigured = true;
         }
 

--- a/classes/Translator.php
+++ b/classes/Translator.php
@@ -1,6 +1,7 @@
 <?php namespace Winter\Translate\Classes;
 
 use App;
+use Cache;
 use Schema;
 use Session;
 use Request;
@@ -103,18 +104,16 @@ class Translator
             return $this->isConfigured;
         }
 
-        if (Session::has(self::SESSION_CONFIGURED)) {
-            $result = true;
-        }
-        elseif (App::hasDatabase() && Schema::hasTable('winter_translate_locales')) {
-            Session::put(self::SESSION_CONFIGURED, true);
-            $result = true;
-        }
-        else {
-            $result = false;
+        if (Cache::has(self::SESSION_CONFIGURED)) {
+            return $this->isConfigured = true;
         }
 
-        return $this->isConfigured = $result;
+        if (App::hasDatabase() && Schema::hasTable('winter_translate_locales')) {
+            Cache::put(self::SESSION_CONFIGURED, true);
+            return $this->isConfigured = true;
+        }
+
+        return false;
     }
 
     //


### PR DESCRIPTION
Internally the `Translator` was using the user's session to store the status of the `isConfigured` status. This means that for each new session it would need to run these checks again which makes no sense.

This PR switches the session storage to use cache instead, meaning the check only needs to be done once for all users.