### PR TITLE
Fix translations conflicting between nested fields and translatable root fields of the same name

### DIFF
--- a/classes/EventRegistry.php
+++ b/classes/EventRegistry.php
@@ -53,16 +53,16 @@ class EventRegistry
             $defaultLocale = LocaleModel::getDefault();
             $availableLocales = LocaleModel::listAvailable();
             $fieldsToTranslate = ['title', 'url'];
-            
+
             // Replace specified fields with multilingual versions
             foreach ($fieldsToTranslate as $fieldName) {
                 $widget->fields[$fieldName]['type'] = 'mltext';
-                
+
                 foreach ($availableLocales as $code => $locale) {
                     if (!$defaultLocale || $defaultLocale->code === $code) {
                         continue;
                     }
-                    
+
                     // Add data locker fields for the different locales under the `viewBag[locale]` property
                     $widget->fields["viewBag[locale][$code][$fieldName]"] = [
                         'cssClass' => 'hidden',
@@ -134,11 +134,11 @@ class EventRegistry
             $widget->fields = $this->processFormMLFields($widget->fields, $model);
         }
 
-        if (!empty($widget->tabs['fields'])) {
+        if (!empty($widget->tabs['fields']) && !$widget->isNested) {
             $widget->tabs['fields'] = $this->processFormMLFields($widget->tabs['fields'], $model);
         }
 
-        if (!empty($widget->secondaryTabs['fields'])) {
+        if (!empty($widget->secondaryTabs['fields']) && !$widget->isNested) {
             $widget->secondaryTabs['fields'] = $this->processFormMLFields($widget->secondaryTabs['fields'], $model);
         }
     }

--- a/classes/EventRegistry.php
+++ b/classes/EventRegistry.php
@@ -126,19 +126,19 @@ class EventRegistry
         }
 
 
-        if (!$model->hasTranslatableAttributes()) {
+        if (!$model->hasTranslatableAttributes() || $widget->isNested) {
             return;
         }
 
-        if (!empty($widget->fields) && !$widget->isNested) {
+        if (!empty($widget->fields)) {
             $widget->fields = $this->processFormMLFields($widget->fields, $model);
         }
 
-        if (!empty($widget->tabs['fields']) && !$widget->isNested) {
+        if (!empty($widget->tabs['fields'])) {
             $widget->tabs['fields'] = $this->processFormMLFields($widget->tabs['fields'], $model);
         }
 
-        if (!empty($widget->secondaryTabs['fields']) && !$widget->isNested) {
+        if (!empty($widget->secondaryTabs['fields'])) {
             $widget->secondaryTabs['fields'] = $this->processFormMLFields($widget->secondaryTabs['fields'], $model);
         }
     }


### PR DESCRIPTION
If a root field that is marked as translatable has the same name as a field in a nested form, the nested field was previously also appearing as translatable. On save, the value of the nested field would overwrite the value of the root field. This should fix this from occurring