### PR TITLE
Replace href="#" with "javascript:;"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ If translated, the text above will appear as whatever language is selected by th
 
     <p>
         Switch language to:
-        <a href="#" data-request="onSwitchLocale" data-request-data="locale: 'en'">English</a>,
-        <a href="#" data-request="onSwitchLocale" data-request-data="locale: 'ru'">Russian</a>
+        <a href="javascript:;" data-request="onSwitchLocale" data-request-data="locale: 'en'">English</a>,
+        <a href="javascript:;" data-request="onSwitchLocale" data-request-data="locale: 'ru'">Russian</a>
     </p>
 
 ## Message translation


### PR DESCRIPTION
Bugs can occur when using "#" as href value.
In my opinion, these should be button's instead of a's but I will leave that in the middle

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->