### PR TITLE
prevents browser autofill off translated inputs

### DIFF
--- a/traits/mlcontrol/partials/_locale_values.htm
+++ b/traits/mlcontrol/partials/_locale_values.htm
@@ -8,6 +8,7 @@
         type="hidden"
         name="<?= $field->getName('RLTranslate['.$code.']') ?>"
         value="<?= e($value) ?>"
+        autocomplete="off"
         data-locale-value="<?= $code ?>"
         <?= $field->getAttributes() ?>
     />


### PR DESCRIPTION
Some browsers (like Firefox) aggressivly autofill inputs (event hidden ones) when not providing the autocomplete="off" attribute. In Firefox this was preventing the inputs to display the correct values when switching the language even after a page refresh/reload.