### PR TITLE
Make sure CMS module is installed and enabled before extending \Cms\Classes\Page

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -201,7 +201,7 @@ class Plugin extends PluginBase
      */
     protected function extendCmsModule(): void
     {
-
+        // Verify that the CMS module is installed and enabled before extending it
         if (!class_exists('\Cms\Classes\Page') || !in_array('Cms', config('cms.loadModules'))) {
             return;
         }

--- a/Plugin.php
+++ b/Plugin.php
@@ -201,6 +201,11 @@ class Plugin extends PluginBase
      */
     protected function extendCmsModule(): void
     {
+
+        if (!class_exists('\Cms\Classes\Page') || !in_array('Cms', config('cms.loadModules'))) {
+            return;
+        }
+        
         /*
          * Handle translated page URLs
          */


### PR DESCRIPTION
This should prevent error of `class \Cms\Classes\Page not found` when using Translate plugin in projects which don't use CMS module.