### PR TITLE
fixes error when using translatabe model behavior and lang() shorthand

### DIFF
--- a/classes/TranslatableBehavior.php
+++ b/classes/TranslatableBehavior.php
@@ -351,7 +351,7 @@ abstract class TranslatableBehavior extends ExtensionBase
      * @param  string|null $context
      * @return self
      */
-    public function lang($context = null): self
+    public function lang($context = null)
     {
         $this->translateContext($context);
 


### PR DESCRIPTION
Due to the strict return type it throwed errors as the implementing model was of a different data type the the behavior.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->