### PR TITLE
Fix getLocaleFieldName behavior with empty formField arrayName

### DIFF
--- a/traits/MLControl.php
+++ b/traits/MLControl.php
@@ -188,14 +188,14 @@ trait MLControl
 
     public function getLocaleFieldName($code)
     {
-        if ($this->isLongFormNeeded()) {
+        $suffix = '';
+        
+        if ($this->isLongFormNeeded() && empty($this->formField->arrayName)) {
             $names = HtmlHelper::nameToArray($this->formField->arrayName);
-            $name = $this->formField->getName('RLTranslate[' . $code . '][' . implode('][', $names) . ']');
-        } else {
-            $name = $this->formField->getName('RLTranslate['.$code.']');
+            $suffix = '[' . implode('][', $names) . ']';
         }
 
-        return $name;
+        return $this->formField->getName('RLTranslate['.$code.']' . $suffix);
     }
 
     /**

--- a/traits/MLControl.php
+++ b/traits/MLControl.php
@@ -190,7 +190,7 @@ trait MLControl
     {
         $suffix = '';
         
-        if ($this->isLongFormNeeded() && empty($this->formField->arrayName)) {
+        if ($this->isLongFormNeeded() && !empty($this->formField->arrayName)) {
             $names = HtmlHelper::nameToArray($this->formField->arrayName);
             $suffix = '[' . implode('][', $names) . ']';
         }


### PR DESCRIPTION
Fixes the issue where formFields with an empty arrayName property would produce unexpected names (such as `RLTranslate[en][][viewBag][title]` in the case of the static pages plugin).