### PR TITLE
Fix issue with loading translated data with arrayNames

### DIFF
--- a/traits/MLControl.php
+++ b/traits/MLControl.php
@@ -146,6 +146,10 @@ trait MLControl
     {
         $key = $this->valueFrom ?: $this->fieldName;
 
+        if (!empty($this->formField->arrayName)) {
+            $key = $this->formField->arrayName.'['.$key.']';
+        }
+
         /*
          * Get the translated values from the model
          */
@@ -205,6 +209,10 @@ trait MLControl
     {
         $localeData = $this->getLocaleSaveData();
         $key = $this->valueFrom ?: $this->fieldName;
+
+        if (!empty($this->formField->arrayName)) {
+            $key = $this->formField->arrayName.'['.$key.']';
+        }
 
         /*
          * Set the translated values to the model


### PR DESCRIPTION
A previous PR I did, #83, added a fix for obtaining data with arrayNames in `MLControl`'s `getLocaleFieldName` method. However, loading data with arrayNames was not implemented. This PR aims to fix this issue by doing a basic implementation within the `getLocaleValue` and `getLocaleSaveValue` methods.
It has not been thoroughly tested; the main tests were for an implementation with the Blocks plugin, which uses arrayNames.

Any input is welcome.