### PR TITLE
Fix Plugin extendModel

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -408,7 +408,7 @@ class Plugin extends PluginBase
         if (!$model->propertyExists('translatable')) {
             $model->addDynamicProperty('translatable', $translatableAttributes);
         } else {
-            $model->translatable = array_merge($model->translatable, $translatableAttributes);
+            $model->extendableSet('translatable', array_merge($model->translatable, $translatableAttributes));
         }
 
         if ($type === 'page') {


### PR DESCRIPTION
Fix property `translatable` is not merged when `$translatePlugin->extendModel` is called in multiple times.

I need to add custom field on CMS Page with translation too (in my plugin).  I was using `backend.form.extendFields` event to add `meta_keywords` field with type `mltext`. This code to add translation to it.

``` php
/** @var \Winter\Translate\Plugin */
$translatePlugin =  PluginManager::instance()->findByIdentifier("Winter.Translate", true);

 /** @param \Cms\Classes\Page $model */
Page::extend(function ($model) use ($translatePlugin, $translatable) {
    $translatePlugin->extendModel($model, 'page', ['meta_keywords']);
});
```

But it remove translation to other fields `title`, `url`, etc.. After I debug it, I found that `exetendModel` function is not merging the translatable attributes. Current code:

``` php
public function extendModel($model, string $type, array $translatableAttributes = [])
{
    if (!$model->propertyExists('translatable')) {
        $model->addDynamicProperty('translatable', $translatableAttributes);
    } else {
        $model->translatable = array_merge($model->translatable, $translatableAttributes);
    }
```
if (dynamic) property already exists, because was called in my plugin. Then this code fail to merge the attributes.
Because the getter function will prioritize the attribute from dynamic properties, but the setter will set on instance attributes directly.

![image](https://github.com/user-attachments/assets/9da2745b-1cf5-47e2-8a62-da015dccbc3e)

Leaving condition like this:
![image](https://github.com/user-attachments/assets/b2615ec8-21d9-454c-ba13-85c022aea4a3)

Theres 2 property, in instance attributes and in dynamic properties with different values.

This PR fixt that, with setting the attributes in dynamic property
