### PR TITLE
feat(config): add redirectStatus option

### DIFF
--- a/components/LocalePicker.php
+++ b/components/LocalePicker.php
@@ -86,11 +86,14 @@ class LocalePicker extends ComponentBase
         $this->translator->setLocale($locale);
 
         $pageUrl = $this->withPreservedQueryString($this->makeLocaleUrlFromPage($locale), $locale);
-        if ($this->property('forceUrl')) {
-            return Redirect::to($this->translator->getPathInLocale($pageUrl, $locale));
-        }
+        $redirectUrl = $this->property('forceUrl')
+            ? $this->translator->getPathInLocale($pageUrl, $locale)
+            : $pageUrl;
 
-        return Redirect::to($pageUrl);
+        return Redirect::to(
+		$redirectUrl,
+		Config::get('winter.translate::redirectStatus')
+	);
     }
 
     protected function redirectForceUrl()
@@ -112,7 +115,8 @@ class LocalePicker extends ComponentBase
                 $this->withPreservedQueryString(
                     $this->translator->getCurrentPathInLocale($locale),
                     $locale
-                )
+                ),
+                Config::get('winter.translate::redirectStatus')
             );
         } elseif ( $locale == $this->translator->getDefaultLocale()) {
             return;

--- a/config/config.php
+++ b/config/config.php
@@ -51,4 +51,16 @@ return [
 
     'disableLocalePrefixRoutes' => env('TRANSLATE_DISABLE_PREFIX_ROUTES', false),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Redirect Status Code
+    |--------------------------------------------------------------------------
+    |
+    | Specifies the HTTP status code to use for redirects.
+    | Default is 302 (Found).
+    |
+    */
+
+    'redirectStatus' => env('TRANSLATE_REDIRECT_STATUS', 302),
+
 ];


### PR DESCRIPTION
Introduces a `redirectStatus` config option to set the HTTP status code for redirects managed by the plugin. Redirects now use the value from config instead of the default 302, allowing for more flexible redirect behavior.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->