### PR TITLE
Adding the ability to use machine translation providers to the copy feature

### DIFF
--- a/ProviderFactory.php
+++ b/ProviderFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Winter\Translate;
+
+use Illuminate\Support\Facades\Config;
+use Winter\Translate\Providers\GoogleTranslateProvider;
+use Winter\Translate\Providers\DeepLTranslateProvider;
+use Winter\Translate\Contracts\TranslationProvider;
+
+class ProviderFactory
+{
+    public static function create(string $provider): TranslationProvider
+    {
+        $config = Config::get("winter.translate::providers.$provider");
+
+        if (!$config) {
+            throw new \Exception("No provider found: $provider");
+        }
+
+        return match ($provider) {
+            'google' => new GoogleTranslateProvider($config),
+            'deepl'  => new DeepLTranslateProvider($config),
+            default  => throw new \Exception("No provider found: $provider"),
+        };
+    }
+}

--- a/assets/css/multilingual.css
+++ b/assets/css/multilingual.css
@@ -1,3 +1,4 @@
+.ml-modal label{color:#333 !important;text-transform:none !important}
 .field-multilingual{position:relative}
 .field-multilingual .form-control:focus{z-index:20}
 .field-multilingual .ml-btn,
@@ -51,6 +52,7 @@
 .field-multilingual.field-multilingual-richeditor .ml-btn{border-radius:0;border-bottom-left-radius:0.375rem}
 .field-multilingual.field-multilingual-markdowneditor .ml-dropdown-menu,
 .field-multilingual.field-multilingual-richeditor .ml-dropdown-menu{top:28px;right:1px}
+.field-multilingual .loading-indicator{z-index:99}
 .field-multilingual.field-multilingual-repeater .ml-dropdown-menu,
 .field-multilingual.field-multilingual-nestedform .ml-dropdown-menu,
 .field-multilingual.field-multilingual-repeater .ml-copy-dropdown>.dropdown-menu,

--- a/assets/css/multilingual.css
+++ b/assets/css/multilingual.css
@@ -1,5 +1,6 @@
 .ml-modal label{color:#333 !important;text-transform:none !important}
 .field-multilingual{position:relative}
+.field-multilingual .lang-code-display{margin-bottom:2rem;text-transform:uppercase}
 .field-multilingual .form-control:focus{z-index:20}
 .field-multilingual .ml-btn,
 .field-multilingual .ml-copy-btn{z-index:12;position:absolute;top:1px;bottom:1px;right:1px;width:auto;width:44px;height:36px;color:#7b7b7b;background-color:#F8F6F3;box-shadow:none;font-size:11px;letter-spacing:1px;text-transform:uppercase;margin:0 !important;padding:0 12px;border-top-left-radius:0;border-bottom-left-radius:0;transition:color 420ms ease}

--- a/assets/js/multilingual.js
+++ b/assets/js/multilingual.js
@@ -116,7 +116,7 @@
 
     MultiLingual.prototype.getProvider = function() {
         const $select = $('select[name^="translation_provider_"]', this.$modal);
-        return $select.val() ?? 'standard';
+        return $select.val() ?? '';
     }
 
     MultiLingual.prototype.setLocaleValue = function(value, locale) {
@@ -130,7 +130,7 @@
 
     MultiLingual.prototype.autoTranslate = function(copyFromLocale, provider) {
         var self = this
-        if (provider == "standard") {
+        if (provider === '') {
             return
         }
         var currentLocale = this.activeLocale

--- a/assets/js/multilingual.js
+++ b/assets/js/multilingual.js
@@ -115,8 +115,8 @@
     }
 
     MultiLingual.prototype.getProvider = function() {
-        const $selected = $('input:checked', this.$modal)
-        return $selected.val() || 'standard'
+        const $select = $('select[name^="translation_provider_"]', this.$modal);
+        return $select.val() ?? 'standard';
     }
 
     MultiLingual.prototype.setLocaleValue = function(value, locale) {
@@ -153,8 +153,10 @@
             },
             success: function(data) {
                 self.$el.trigger('autoTranslateSuccess.oc.multilingual', [data])
-                self.$el.loadIndicator('hide')
                 this.success(data)
+            },
+            complete: function() {
+                self.$el.loadIndicator('hide')
             }
         })
     }

--- a/assets/less/multilingual.less
+++ b/assets/less/multilingual.less
@@ -4,11 +4,6 @@
 @copy-btn-right-offset: 41px;
 @copy-btn-top-offset: 28px;
 
-.ml-modal label {
-    color: #333 !important;
-    text-transform: none !important;
-}
-
 .field-multilingual {
     position: relative;
 

--- a/assets/less/multilingual.less
+++ b/assets/less/multilingual.less
@@ -4,6 +4,11 @@
 @copy-btn-right-offset: 41px;
 @copy-btn-top-offset: 28px;
 
+.ml-modal label {
+    color: #333 !important;
+    text-transform: none !important;
+}
+
 .field-multilingual {
     position: relative;
 
@@ -37,8 +42,9 @@
             right: 0;
         }
     }
-    .dropdown.ml-dropdown.open > .dropdown-menu,
-    .dropdown.ml-copy-dropdown.open > .dropdown-menu {
+
+    .dropdown.ml-dropdown.open>.dropdown-menu,
+    .dropdown.ml-copy-dropdown.open>.dropdown-menu {
         top: @copy-btn-top-offset;
     }
 
@@ -46,12 +52,14 @@
     // Repeater-specific override
     &.field-multilingual-repeater,
     &.field-multilingual-nestedform {
+
         .ml-btn,
         .ml-copy-btn {
             top: -36px;
         }
-        .dropdown.ml-dropdown.open > .dropdown-menu,
-        .dropdown.ml-copy-dropdown.open > .dropdown-menu {
+
+        .dropdown.ml-dropdown.open>.dropdown-menu,
+        .dropdown.ml-copy-dropdown.open>.dropdown-menu {
             top: -10px;
         }
     }
@@ -60,15 +68,17 @@
     // media finder specific stuff
     &.field-multilingual-mediafinder {
 
-        .dropdown.ml-dropdown.open > .dropdown-menu,
-        .dropdown.ml-copy-dropdown.open > .dropdown-menu {
+        .dropdown.ml-dropdown.open>.dropdown-menu,
+        .dropdown.ml-copy-dropdown.open>.dropdown-menu {
             top: -10px;
         }
 
-        .dropdown.ml-dropdown:not(.open),// to stop it from overlapping with the upload button
+        .dropdown.ml-dropdown:not(.open),
+        // to stop it from overlapping with the upload button
         .dropdown.ml-copy-dropdown:not(.open) {
             height: 3px;
         }
+
         .ml-btn,
         .ml-copy-btn {
             top: -36px;
@@ -87,12 +97,13 @@
         }
 
         .ml-dropdown-menu,
-        .ml-copy-dropdown > .dropdown-menu {
+        .ml-copy-dropdown>.dropdown-menu {
             top: @copy-btn-top-offset;
         }
     }
 
     &.field-multilingual-markdowneditor {
+
         .mode-tab .editor-write,
         .mode-split .editor-preview {
             padding-right: 2rem;
@@ -105,18 +116,22 @@
 
     &.field-multilingual-markdowneditor,
     &.field-multilingual-richeditor {
+
         .ml-btn,
         .ml-copy-btn {
             height: 38px;
         }
-        .dropdown.ml-dropdown.open > .dropdown-menu,
-        .dropdown.ml-copy-dropdown.open > .dropdown-menu {
+
+        .dropdown.ml-dropdown.open>.dropdown-menu,
+        .dropdown.ml-copy-dropdown.open>.dropdown-menu {
             top: 37px;
         }
+
         .dropdown.ml-dropdown:not(.open),
         .dropdown.ml-copy-dropdown:not(.open) {
             height: 3px;
         }
+
         .ml-btn {
             border-radius: 0;
             border-bottom-left-radius: .375rem;
@@ -128,11 +143,16 @@
         }
     }
 
+    .loading-indicator {
+        z-index: 99;
+    }
+
     &.field-multilingual-repeater,
     &.field-multilingual-nestedform {
+
         .ml-dropdown-menu,
-        .ml-copy-dropdown > .dropdown-menu {
-            top: calc(@copy-btn-top-offset - 20px );
+        .ml-copy-dropdown>.dropdown-menu {
+            top: calc(@copy-btn-top-offset - 20px);
             right: 0;
         }
     }
@@ -141,6 +161,7 @@
 // Fancy layout overrides
 .fancy-layout {
     .form-tabless-fields .field-multilingual {
+
         .ml-btn,
         .ml-copy-btn {
             background-color: rgba(248, 246, 243, 0.75);

--- a/assets/less/multilingual.less
+++ b/assets/less/multilingual.less
@@ -12,6 +12,10 @@
 .field-multilingual {
     position: relative;
 
+    .lang-code-display {
+        margin-bottom: 2rem;
+        text-transform: uppercase;
+    }
     .form-control:focus {
         z-index: 20;
     }

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,18 @@
     "require": {
         "php": ">=7.2",
         "winter/wn-backend-module": ">=1.2.8",
-        "composer/installers": "~1.0"
+        "composer/installers": "~1.0",
+        "guzzlehttp/guzzle": "^7.10"
     },
     "replace": {
         "rainlab/translate-plugin": "~1.6"
     },
     "extra": {
         "installer-name": "translate"
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
+        }
     }
 }

--- a/config/config.php
+++ b/config/config.php
@@ -98,16 +98,17 @@ return [
     |
     | Sets the default provider used when performing auto translation.
     | This must match one of the providers defined in the "providers" section,
-    | otherwise a 'standard' copy will be performed.
+    | otherwise a standard copy will be performed (empty string = no translation).
     |
-    | Default is standard as users will need to setup access to a provider
+    | Default is empty string as users will need to setup access to a provider.
+    | Empty string means "None" - just copy content without translation.
     |
     | Example:
     |   TRANSLATE_PROVIDER=google
     |
     */
 
-    'defaultProvider' => env('TRANSLATE_PROVIDER', 'standard'),
+    'defaultProvider' => env('TRANSLATE_PROVIDER', ''),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/config.php
+++ b/config/config.php
@@ -65,28 +65,67 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Auto Translation Providers
+    | Auto Translation Whitelist
     |--------------------------------------------------------------------------
     |
-    | Configure the translation API services used by your application.
-    | You may define multiple providers and pick one as the default.
+    | Specifies which form inputs should be automatically translated when using
+    | auto-translation.
     |
-    | Supported Examples: "google"
+    | Example scenario:
+    |       fields:
+    |           does_not_work: <- this is the key you put into the whitelist
+    |               label: Does not work
+    |               trigger:
+    |                   action: hide
+    |                   field: is_delayed
+    |                   condition: checked
+    |
+    | Important Notes:
+    | - Only applies to formwidgets that have multiple inputs (e.g. NestedForm),
+    |   otherwise it's ignored.
+    |
+    | Example:
+    |   'autoTranslateWhiteList' => ['name', 'content']
     |
     */
 
-    // NOTE: if you have multiple fields named the same thing they will be like name, name2, name3, etc
-    // this will only translate the ones explicitly defined, in this case only name will be translated
-    'autoTranslateWhiteList' => [
-        'does_not_work',
-        'does_not_work3',
-        'name',
-        'content',
-        'works',
-        'value',
-    ],
+    'autoTranslateWhiteList' => ['does_not_work'],
 
-    'defaultProvider' => env('TRANSLATE_PROVIDER', 'google'),
+    /*
+    |--------------------------------------------------------------------------
+    | Default Auto Translation Provider
+    |--------------------------------------------------------------------------
+    |
+    | Sets the default provider used when performing auto translation.
+    | This must match one of the providers defined in the "providers" section,
+    | otherwise a 'standard' copy will be performed.
+    |
+    | Default is standard as users will need to setup access to a provider
+    |
+    | Example:
+    |   TRANSLATE_PROVIDER=google
+    |
+    */
+
+    'defaultProvider' => env('TRANSLATE_PROVIDER', 'standard'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto Translation Providers
+    |--------------------------------------------------------------------------
+    |
+    | Configure the translation API services available to your application.
+    | You may define multiple providers; each provider will appear in the
+    | dropdown list when choosing a translation service.
+    |
+    | To create new providers create a new class that implements TranslationProvider
+    | and add it to the ProviderFactory, see translate/providers.
+    |
+    | Each provider must include:
+    |   - url : API endpoint
+    |   - key : API key or authentication token
+    |
+    */
 
     'providers' => [
 
@@ -95,9 +134,11 @@ return [
             'key' => env('GOOGLE_TRANSLATE_KEY', ''),
         ],
 
-        'deepl' => [
-            'url' => env('DEEPL_API_URL', 'https://api.deepl.com/v2/translate'),
-            'key' => env('DEEPL_API_KEY', ''),
-        ],
+        // Example for adding an additional provider:
+        //
+        // 'deepl' => [
+        //     'url' => env('DEEPL_API_URL', 'https://api.deepl.com/v2/translate'),
+        //     'key' => env('DEEPL_API_KEY', ''),
+        // ],
     ],
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -89,7 +89,7 @@ return [
     |
     */
 
-    'autoTranslateWhiteList' => ['does_not_work'],
+    'autoTranslateWhiteList' => [],
 
     /*
     |--------------------------------------------------------------------------

--- a/config/config.php
+++ b/config/config.php
@@ -63,4 +63,41 @@ return [
 
     'redirectStatus' => env('TRANSLATE_REDIRECT_STATUS', 302),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Auto Translation Providers
+    |--------------------------------------------------------------------------
+    |
+    | Configure the translation API services used by your application.
+    | You may define multiple providers and pick one as the default.
+    |
+    | Supported Examples: "google"
+    |
+    */
+
+    // NOTE: if you have multiple fields named the same thing they will be like name, name2, name3, etc
+    // this will only translate the ones explicitly defined, in this case only name will be translated
+    'autoTranslateWhiteList' => [
+        'does_not_work',
+        'does_not_work3',
+        'name',
+        'content',
+        'works',
+        'value',
+    ],
+
+    'defaultProvider' => env('TRANSLATE_PROVIDER', 'google'),
+
+    'providers' => [
+
+        'google' => [
+            'url' => env('GOOGLE_TRANSLATE_URL', 'https://translation.googleapis.com/language/translate/v2'),
+            'key' => env('GOOGLE_TRANSLATE_KEY', ''),
+        ],
+
+        'deepl' => [
+            'url' => env('DEEPL_API_URL', 'https://api.deepl.com/v2/translate'),
+            'key' => env('DEEPL_API_KEY', ''),
+        ],
+    ],
 ];

--- a/contracts/TranslationProvider.php
+++ b/contracts/TranslationProvider.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Winter\Translate\Contracts;
+
+interface TranslationProvider
+{
+    /**
+     * @param string[] $input
+     * @return string[] translated output
+     */
+    public function translate(array $input, string $targetLocale, string $currentLocale): array;
+}

--- a/formwidgets/MLBlocks.php
+++ b/formwidgets/MLBlocks.php
@@ -18,6 +18,7 @@ use Winter\Translate\Models\Locale;
 class MLBlocks extends Blocks
 {
     use \Winter\Translate\Traits\MLControl;
+    use \Winter\Translate\Traits\MLAutoTranslate;
 
     /**
      * {@inheritDoc}
@@ -107,8 +108,18 @@ class MLBlocks extends Blocks
     public function onCopyItemLocale()
     {
         $copyFromLocale = post('_blocks_copy_locale');
+        $currentLocale = post('_blocks_current_locale');
+        $provider = post('_provider');
 
         $copyFromValues = $this->getLocaleSaveDataAsArray($copyFromLocale);
+        if ($provider !== 'standard' && !empty($copyFromValues)) {
+            $copyFromValues = $this->autoTranslateArray(
+                $copyFromValues,
+                $currentLocale,
+                $copyFromLocale,
+                $provider
+            );
+        }
 
         $this->reprocessLocaleItems($copyFromValues);
         foreach ($this->formWidgets as $key => $widget) {

--- a/formwidgets/MLBlocks.php
+++ b/formwidgets/MLBlocks.php
@@ -112,7 +112,7 @@ class MLBlocks extends Blocks
         $provider = post('_provider');
 
         $copyFromValues = $this->getLocaleSaveDataAsArray($copyFromLocale);
-        if ($provider !== 'standard' && !empty($copyFromValues)) {
+        if ($provider !== '' && !empty($copyFromValues)) {
             $copyFromValues = $this->autoTranslateArray(
                 $copyFromValues,
                 $currentLocale,

--- a/formwidgets/MLMarkdownEditor.php
+++ b/formwidgets/MLMarkdownEditor.php
@@ -15,6 +15,7 @@ use Winter\Translate\Models\Locale;
 class MLMarkdownEditor extends MarkdownEditor
 {
     use \Winter\Translate\Traits\MLControl;
+    use \Winter\Translate\Traits\MLAutoTranslate;
 
     /**
      * {@inheritDoc}

--- a/formwidgets/MLMediaFinder.php
+++ b/formwidgets/MLMediaFinder.php
@@ -62,6 +62,7 @@ class MLMediaFinder extends MediaFinder
         parent::prepareVars();
         $this->prepareLocaleVars();
         // make root path of media files accessible
+        $this->vars['autoTranslatable'] = false;
         $this->vars['mediaPath'] = $this->mediaPath = MediaLibrary::url('/');
     }
 

--- a/formwidgets/MLNestedForm.php
+++ b/formwidgets/MLNestedForm.php
@@ -15,6 +15,7 @@ use Request;
 class MLNestedForm extends NestedForm
 {
     use \Winter\Translate\Traits\MLControl;
+    use \Winter\Translate\Traits\MLAutoTranslate;
 
     /**
      * {@inheritDoc}
@@ -97,8 +98,18 @@ class MLNestedForm extends NestedForm
     public function onCopyItemLocale()
     {
         $copyFromLocale = post('_repeater_copy_locale');
+        $currentLocale = post('_repeater_current_locale');
+        $provider = post('_provider');
 
         $copyFromValues = $this->getLocaleSaveDataAsArray($copyFromLocale);
+        if ($provider !== 'standard' && !empty($copyFromValues)) {
+            $copyFromValues = $this->autoTranslateArray(
+                $copyFromValues,
+                $currentLocale,
+                $copyFromLocale,
+                $provider
+            );
+        }
 
         $this->reprocessLocaleItems($copyFromValues);
 

--- a/formwidgets/MLNestedForm.php
+++ b/formwidgets/MLNestedForm.php
@@ -102,7 +102,7 @@ class MLNestedForm extends NestedForm
         $provider = post('_provider');
 
         $copyFromValues = $this->getLocaleSaveDataAsArray($copyFromLocale);
-        if ($provider !== 'standard' && !empty($copyFromValues)) {
+        if ($provider !== '' && !empty($copyFromValues)) {
             $copyFromValues = $this->autoTranslateArray(
                 $copyFromValues,
                 $currentLocale,

--- a/formwidgets/MLRepeater.php
+++ b/formwidgets/MLRepeater.php
@@ -112,7 +112,7 @@ class MLRepeater extends Repeater
         $provider = post('_provider');
 
         $copyFromValues = $this->getLocaleSaveDataAsArray($copyFromLocale);
-        if ($provider !== 'standard' && !empty($copyFromValues)) {
+        if ($provider !== '' && !empty($copyFromValues)) {
             $copyFromValues = $this->autoTranslateArray(
                 $copyFromValues,
                 $currentLocale,

--- a/formwidgets/MLRepeater.php
+++ b/formwidgets/MLRepeater.php
@@ -18,6 +18,7 @@ use Winter\Translate\Models\Locale;
 class MLRepeater extends Repeater
 {
     use \Winter\Translate\Traits\MLControl;
+    use \Winter\Translate\Traits\MLAutoTranslate;
 
     /**
      * {@inheritDoc}
@@ -107,8 +108,18 @@ class MLRepeater extends Repeater
     public function onCopyItemLocale()
     {
         $copyFromLocale = post('_repeater_copy_locale');
+        $currentLocale = post('_repeater_current_locale');
+        $provider = post('_provider');
 
         $copyFromValues = $this->getLocaleSaveDataAsArray($copyFromLocale);
+        if ($provider !== 'standard' && !empty($copyFromValues)) {
+            $copyFromValues = $this->autoTranslateArray(
+                $copyFromValues,
+                $currentLocale,
+                $copyFromLocale,
+                $provider
+            );
+        }
 
         $this->reprocessLocaleItems($copyFromValues);
         foreach ($this->formWidgets as $key => $widget) {

--- a/formwidgets/MLRichEditor.php
+++ b/formwidgets/MLRichEditor.php
@@ -15,6 +15,7 @@ use Winter\Translate\Models\Locale;
 class MLRichEditor extends RichEditor
 {
     use \Winter\Translate\Traits\MLControl;
+    use \Winter\Translate\Traits\MLAutoTranslate;
 
     /**
      * {@inheritDoc}

--- a/formwidgets/MLText.php
+++ b/formwidgets/MLText.php
@@ -3,6 +3,7 @@
 namespace Winter\Translate\FormWidgets;
 
 use Backend\Classes\FormWidgetBase;
+use Exception;
 
 /**
  * ML Text
@@ -14,6 +15,7 @@ use Backend\Classes\FormWidgetBase;
 class MLText extends FormWidgetBase
 {
     use \Winter\Translate\Traits\MLControl;
+    use \Winter\Translate\Traits\MLAutoTranslate;
 
     /**
      * {@inheritDoc}
@@ -57,5 +59,6 @@ class MLText extends FormWidgetBase
     protected function loadAssets()
     {
         $this->loadLocaleAssets();
+        $this->addJs('js/mltext.js');
     }
 }

--- a/formwidgets/MLTextarea.php
+++ b/formwidgets/MLTextarea.php
@@ -14,6 +14,7 @@ use Backend\Classes\FormWidgetBase;
 class MLTextarea extends FormWidgetBase
 {
     use \Winter\Translate\Traits\MLControl;
+    use \Winter\Translate\Traits\MLAutoTranslate;
 
     /**
      * {@inheritDoc}

--- a/formwidgets/mlblocks/assets/js/mlblocks.js
+++ b/formwidgets/mlblocks/assets/js/mlblocks.js
@@ -104,8 +104,10 @@
                 _provider: provider,
             },
             success: function(data) {
-                self.$el.loadIndicator('hide')
                 this.success(data)
+            },
+            complete: function() {
+                self.$el.loadIndicator('hide')
             }
         })
     }

--- a/formwidgets/mlblocks/assets/js/mlblocks.js
+++ b/formwidgets/mlblocks/assets/js/mlblocks.js
@@ -90,9 +90,8 @@
             this.$el.css('margin-top','36px')
         }
     }
-    MLBlocks.prototype.onCopyLocale = function(e, locale, localeValue) {
-        var self = this,
-            copyFromLocale = this.locale
+    MLBlocks.prototype.onCopyLocale = function(e, {copyFromLocale, copyFromValue, currentLocale, provider}) {
+        var self = this
 
         this.$el
             .addClass('loading-indicator-container size-form-field')
@@ -101,6 +100,8 @@
         this.$el.request(this.options.copyHandler, {
             data: {
                 _blocks_copy_locale: copyFromLocale,
+                _blocks_current_locale: currentLocale,
+                _provider: provider,
             },
             success: function(data) {
                 self.$el.loadIndicator('hide')

--- a/formwidgets/mlmarkdowneditor/assets/js/mlmarkdowneditor.js
+++ b/formwidgets/mlmarkdowneditor/assets/js/mlmarkdowneditor.js
@@ -100,6 +100,7 @@
         if (typeof translatedValue != 'string' || !this.$markdownEditor.data('oc.markdownEditor')) {
             return
         }
+        this.$el.multiLingual('setLocaleValue', translatedValue, data.translatedLocale)
         this.$markdownEditor.markdownEditor('setContent', translatedValue);
     }
 

--- a/formwidgets/mlmarkdowneditor/assets/js/mlmarkdowneditor.js
+++ b/formwidgets/mlmarkdowneditor/assets/js/mlmarkdowneditor.js
@@ -49,6 +49,7 @@
 
         this.$el.on('setLocale.oc.multilingual', this.proxy(this.onSetLocale))
         this.$el.on('copyLocale.oc.multilingual', this.proxy(this.onCopyLocale))
+        this.$el.on('autoTranslateSuccess.oc.multilingual', this.proxy(this.onAutoTranslateSuccess))
         this.$textarea.on('changeContent.oc.markdowneditor', this.proxy(this.onChangeContent))
 
         this.codeEditor.on('blur', this.proxy(this.toggleIsFocused))
@@ -64,6 +65,7 @@
     MLMarkdownEditor.prototype.dispose = function() {
         this.$el.off('setLocale.oc.multilingual', this.proxy(this.onSetLocale))
         this.$el.off('copyLocale.oc.multilingual', this.proxy(this.onCopyLocale))
+        this.$el.off('autoTranslateSuccess.oc.multilingual', this.proxy(this.onAutoTranslateSuccess))
         this.$textarea.off('changeContent.oc.markdowneditor', this.proxy(this.onChangeContent))
         this.$el.off('dispose-control', this.proxy(this.dispose))
         this.codeEditor.off('blur', this.proxy(this.toggleIsFocused))
@@ -86,10 +88,19 @@
         }
     }
 
-    MLMarkdownEditor.prototype.onCopyLocale = function(e, locale, localeValue) {
-        if (typeof localeValue === 'string' && this.$markdownEditor.data('oc.markdownEditor')) {
-            this.$markdownEditor.markdownEditor('setContent', localeValue);
+    MLMarkdownEditor.prototype.onCopyLocale = function(e, {copyFromLocale, copyFromValue, currentLocale, provider}) {
+        if (typeof copyFromValue === 'string' && this.$markdownEditor.data('oc.markdownEditor')) {
+            this.$markdownEditor.markdownEditor('setContent', copyFromValue);
         }
+        this.$el.multiLingual('autoTranslate', copyFromLocale, provider)
+    }
+
+    MLMarkdownEditor.prototype.onAutoTranslateSuccess = function(e, data) {
+        const translatedValue = data.translatedValue[0]
+        if (typeof translatedValue != 'string' || !this.$markdownEditor.data('oc.markdownEditor')) {
+            return
+        }
+        this.$markdownEditor.markdownEditor('setContent', translatedValue);
     }
 
     MLMarkdownEditor.prototype.onChangeContent = function(ev, markdowneditor, value) {

--- a/formwidgets/mlmarkdowneditor/partials/_mlmarkdowneditor.htm
+++ b/formwidgets/mlmarkdowneditor/partials/_mlmarkdowneditor.htm
@@ -6,6 +6,7 @@
     data-copy-confirm="<?= e(trans('winter.translate::lang.locale.copy_confirm')); ?>"
     data-default-locale="<?= $defaultLocale->code ?>"
     data-placeholder-field="#<?= $this->getId('textarea') ?>"
+    data-auto-translate-handler="<?= $this->getEventHandler('onAutoTranslate') ?>"
     class="field-multilingual field-multilingual-markdowneditor dropdown <?= $stretch?'layout-relative stretch':'' ?>"
     >
 

--- a/formwidgets/mlmediafinder/assets/js/mlmediafinder.js
+++ b/formwidgets/mlmediafinder/assets/js/mlmediafinder.js
@@ -96,8 +96,8 @@
         this.setPath(localeValue)
     }
 
-    MLMediaFinder.prototype.onCopyLocale = function(e, locale, localeValue) {
-        this.setPath(localeValue)
+    MLMediaFinder.prototype.onCopyLocale = function(e, {copyFromLocale, copyFromValue, currentLocale, provider}) {
+        this.setPath(copyFromValue)
     }
 
     MLMediaFinder.prototype.setPath = function(localeValue) {

--- a/formwidgets/mlnestedform/assets/js/mlnestedform.js
+++ b/formwidgets/mlnestedform/assets/js/mlnestedform.js
@@ -91,8 +91,10 @@
                 _provider: provider,
             },
             success: function(data) {
-                self.$el.loadIndicator('hide')
                 this.success(data)
+            },
+            complete: function() {
+                self.$el.loadIndicator('hide')
             }
         })
     }

--- a/formwidgets/mlnestedform/assets/js/mlnestedform.js
+++ b/formwidgets/mlnestedform/assets/js/mlnestedform.js
@@ -77,9 +77,8 @@
         BaseProto.dispose.call(this)
     }
 
-    MLNestedForm.prototype.onCopyLocale = function(e, locale, localeValue) {
-        var self = this,
-            copyFromLocale = this.locale
+    MLNestedForm.prototype.onCopyLocale = function(e, {copyFromLocale, copyFromValue, currentLocale, provider}) {
+        var self = this
 
         this.$el
             .addClass('loading-indicator-container size-form-field')
@@ -88,6 +87,8 @@
         this.$el.request(this.options.copyHandler, {
             data: {
                 _repeater_copy_locale: copyFromLocale,
+                _repeater_current_locale: currentLocale,
+                _provider: provider,
             },
             success: function(data) {
                 self.$el.loadIndicator('hide')

--- a/formwidgets/mlrepeater/assets/js/mlrepeater.js
+++ b/formwidgets/mlrepeater/assets/js/mlrepeater.js
@@ -94,8 +94,10 @@
                 _provider: provider,
             },
             success: function(data) {
-                self.$el.loadIndicator('hide')
                 this.success(data)
+            },
+            complete: function() {
+                self.$el.loadIndicator('hide')
             }
         })
     }

--- a/formwidgets/mlrepeater/assets/js/mlrepeater.js
+++ b/formwidgets/mlrepeater/assets/js/mlrepeater.js
@@ -80,9 +80,8 @@
         this.$el.toggleClass('is-empty', isEmpty)
     }
 
-    MLRepeater.prototype.onCopyLocale = function(e, locale, localeValue) {
-        var self = this,
-            copyFromLocale = this.locale
+    MLRepeater.prototype.onCopyLocale = function(e, {copyFromLocale, copyFromValue, currentLocale, provider}) {
+        var self = this
 
         this.$el
             .addClass('loading-indicator-container size-form-field')
@@ -91,6 +90,8 @@
         this.$el.request(this.options.copyHandler, {
             data: {
                 _repeater_copy_locale: copyFromLocale,
+                _repeater_current_locale: currentLocale,
+                _provider: provider,
             },
             success: function(data) {
                 self.$el.loadIndicator('hide')

--- a/formwidgets/mlricheditor/assets/js/mlricheditor.js
+++ b/formwidgets/mlricheditor/assets/js/mlricheditor.js
@@ -105,6 +105,7 @@
         if (typeof translatedValue != 'string' || !this.$richeditor.data('oc.richEditor')) {
             return
         }
+        this.$el.multiLingual('setLocaleValue', translatedValue, data.translatedLocale)
         this.$richeditor.richEditor('setContent', translatedValue);
     }
 

--- a/formwidgets/mlricheditor/assets/js/mlricheditor.js
+++ b/formwidgets/mlricheditor/assets/js/mlricheditor.js
@@ -48,6 +48,7 @@
 
         this.$el.on('setLocale.oc.multilingual', this.proxy(this.onSetLocale))
         this.$el.on('copyLocale.oc.multilingual', this.proxy(this.onCopyLocale))
+        this.$el.on('autoTranslateSuccess.oc.multilingual', this.proxy(this.onAutoTranslateSuccess))
         this.$textarea.on('syncContent.oc.richeditor', this.proxy(this.onSyncContent))
 
         this.editor.events.on('focus', this.proxy(this.toggleIsFocused));
@@ -67,6 +68,7 @@
     MLRichEditor.prototype.dispose = function() {
         this.$el.off('setLocale.oc.multilingual', this.proxy(this.onSetLocale))
         this.$el.off('copyLocale.oc.multilingual', this.proxy(this.onCopyLocale))
+        this.$el.off('autoTranslateSuccess.oc.multilingual', this.proxy(this.onAutoTranslateSuccess))
         this.$textarea.off('syncContent.oc.richeditor', this.proxy(this.onSyncContent))
         $(window).off('resize', this.proxy(this.updateLayout))
         $(window).off('oc.updateUi', this.proxy(this.updateLayout))
@@ -91,10 +93,19 @@
             this.$richeditor.richEditor('setContent', localeValue);
         }
     }
-    MLRichEditor.prototype.onCopyLocale = function(e, locale, localeValue) {
-        if (typeof localeValue === 'string' && this.$richeditor.data('oc.richEditor')) {
-            this.$richeditor.richEditor('setContent', localeValue);
+    MLRichEditor.prototype.onCopyLocale = function(e, {copyFromLocale, copyFromValue, currentLocale, provider}) {
+        if (typeof copyFromValue === 'string' && this.$richeditor.data('oc.richEditor')) {
+            this.$richeditor.richEditor('setContent', copyFromValue);
         }
+        this.$el.multiLingual('autoTranslate', copyFromLocale, provider)
+    }
+
+    MLRichEditor.prototype.onAutoTranslateSuccess = function(e, data) {
+        const translatedValue = data.translatedValue[0]
+        if (typeof translatedValue != 'string' || !this.$richeditor.data('oc.richEditor')) {
+            return
+        }
+        this.$richeditor.richEditor('setContent', translatedValue);
     }
 
     MLRichEditor.prototype.onSyncContent = function(ev, richeditor, value) {

--- a/formwidgets/mlricheditor/partials/_mlricheditor.htm
+++ b/formwidgets/mlricheditor/partials/_mlricheditor.htm
@@ -6,6 +6,7 @@
     data-copy-confirm="<?= e(trans('winter.translate::lang.locale.copy_confirm')); ?>"
     data-default-locale="<?= $defaultLocale->code ?>"
     data-placeholder-field="#<?= $this->getId('textarea') ?>"
+    data-auto-translate-handler="<?= $this->getEventHandler('onAutoTranslate') ?>"
     class="field-multilingual field-multilingual-textarea field-multilingual-richeditor dropdown <?= $stretch?'layout-relative stretch':'' ?>"
     >
 

--- a/formwidgets/mltext/assets/js/mltext.js
+++ b/formwidgets/mltext/assets/js/mltext.js
@@ -58,12 +58,11 @@
     }
 
     MLText.prototype.onAutoTranslateSuccess = function(e, data) {
-        var self = this
         const translatedValue = data.translatedValue[0]
         if (data.translatedValue && data.translatedLocale) {
-            const $visibleInput = $('input.form-control', self.$el)
+            const $visibleInput = $('input.form-control', this.$el)
             $visibleInput.val(translatedValue).trigger('input')
-            self.$el.multiLingual('setLocaleValue', translatedValue, data.translatedLocale)
+            this.$el.multiLingual('setLocaleValue', translatedValue, data.translatedLocale)
         }
     }
 

--- a/formwidgets/mltext/assets/js/mltext.js
+++ b/formwidgets/mltext/assets/js/mltext.js
@@ -1,0 +1,90 @@
+/*
+ * MLText plugin
+ *
+ * Data attributes:
+ * - data-control="mltext" - enables the plugin on an element
+ *
+ * JavaScript API:
+ * $('a#someElement').mlText({ option: 'value' })
+ *
+ */
+
++function($) {
+
+    var Base = $.wn.foundation.base,
+        BaseProto = Base.prototype
+
+    "use strict";
+
+    var MLText = function(element, options) {
+        this.options = options
+        this.$el = $(element)
+        $.wn.foundation.controlUtils.markDisposable(element)
+        Base.call(this)
+
+        this.init()
+    }
+
+    MLText.prototype = Object.create(BaseProto)
+    MLText.prototype.constructor = MLText
+
+    MLText.DEFAULTS = {
+        autoTranslateHandler: null,
+        // switchHan
+        // defaultLocale: 'en'
+    }
+
+    MLText.prototype.init = function() {
+        this.$el.multiLingual()
+
+        // NOTE: this.$el.on('setLocale.oc.multilingual', this.proxy(this.onSetLocale))
+        this.$el.on('copyLocale.oc.multilingual', this.proxy(this.onCopyLocale))
+        this.$el.on('autoTranslateSuccess.oc.multilingual', this.proxy(this.onAutoTranslateSuccess))
+        this.$el.one('dispose-control', this.proxy(this.dispose))
+    }
+
+    MLText.prototype.dispose = function() {
+        this.$el.off('copyLocale.oc.multilingual', this.proxy(this.onCopyLocale))
+        this.$el.off('autoTranslateSuccess.oc.multilingual', this.proxy(this.onAutoTranslateSuccess))
+        this.$el.off('dispose-control', this.proxy(this.dispose))
+
+        this.$el.removeData('oc.mlText')
+        this.$el = null
+        this.options = null
+    }
+
+    MLText.prototype.onCopyLocale = function(e, {copyFromLocale, copyFromValue, currentLocale, provider}) {
+        this.$el.multiLingual('autoTranslate', copyFromLocale, provider)
+    }
+
+    MLText.prototype.onAutoTranslateSuccess = function(e, data) {
+        var self = this
+        const translatedValue = data.translatedValue[0]
+        if (data.translatedValue && data.translatedLocale) {
+            const $visibleInput = $('input.form-control', self.$el)
+            $visibleInput.val(translatedValue).trigger('input')
+            self.$el.multiLingual('setLocaleValue', translatedValue, data.translatedLocale)
+        }
+    }
+
+    $.fn.mlText = function(option) {
+        return this.each(function() {
+            var $this = $(this)
+            var data = $this.data('oc.mlText')
+            var options = $.extend({}, MLText.DEFAULTS, $this.data(), typeof option == 'object' && option)
+
+            if (!data) $this.data('oc.mlText', (data = new MLText(this, options)))
+            if (typeof option == 'string') data[option]()
+        })
+    }
+
+    $.fn.mlText.noConflict = function() {
+        $.fn.mlText = old
+        return this
+    }
+
+    $(document).render(function() {
+        $('[data-control="mltext"]').mlText()
+    })
+
+}(window.jQuery);

--- a/formwidgets/mltext/partials/_mltext.htm
+++ b/formwidgets/mltext/partials/_mltext.htm
@@ -3,7 +3,7 @@
     <span class="form-control"><?= $field->value ? e($field->value) : '&nbsp;' ?></span>
 <?php else: ?>
     <div
-        id="<?= $this->getId() ?>"
+        id="<?= $this->getId('mlControl') ?>"
         data-control="mltext"
         data-copy-confirm="<?= e(trans('winter.translate::lang.locale.copy_confirm')); ?>"
         data-default-locale="<?= $defaultLocale->code ?>"

--- a/formwidgets/mltext/partials/_mltext.htm
+++ b/formwidgets/mltext/partials/_mltext.htm
@@ -4,10 +4,11 @@
 <?php else: ?>
     <div
         id="<?= $this->getId() ?>"
-        data-control="multilingual"
+        data-control="mltext"
         data-copy-confirm="<?= e(trans('winter.translate::lang.locale.copy_confirm')); ?>"
         data-default-locale="<?= $defaultLocale->code ?>"
         data-placeholder-field="#<?= $field->getId('placeholderField') ?>"
+        data-auto-translate-handler="<?= $this->getEventHandler('onAutoTranslate') ?>"
         class="field-multilingual field-multilingual-text dropdown">
 
         <input

--- a/formwidgets/mltextarea/assets/js/mltextarea.js
+++ b/formwidgets/mltextarea/assets/js/mltextarea.js
@@ -1,34 +1,125 @@
-function updateTextareaLayout($element) {
+/*
+ * MLTextarea plugin
+ *
+ * Data attributes:
+ * - data-control="mltextarea" - enables the plugin on an element
+ * - data-auto-translate-handler - AJAX handler for auto translation
+ *
+ * JavaScript API:
+ * $('div#someElement').mlTextarea({ option: 'value' })
+ */
 
-    // get elements
-    const $parent = $element.parentElement
-    const $btn = $parent.querySelector('.ml-btn[data-active-locale]')
-    const $dropdown = $parent.querySelector('.ml-dropdown-menu[data-locale-dropdown]')
-    const $copyBtn = $parent.querySelector('.ml-copy-btn')
-    const $copyDropdown = $parent.querySelector('.ml-copy-dropdown-menu')
++function($) {
+    var Base = $.wn.foundation.base,
+        BaseProto = Base.prototype
 
-    // set ML button position
-    const elementHeight = $element.offsetHeight
-    const scrollHeight = $element.scrollHeight
-    const showScrollbar = (scrollHeight - elementHeight) > 0 ? true : false
-
-    if (showScrollbar) {
-        const scrollbarWidth = $element.offsetWidth - $element.clientWidth
-        $element.style.paddingRight = `${scrollbarWidth + 23}px`
-        $btn.style.right = `${scrollbarWidth - 1}px`
-        $btn.style.borderTopRightRadius = '0px'
-        $dropdown.style.right = `${scrollbarWidth - 2}px`
-        $copyBtn.style.right = `${scrollbarWidth - 1}px`
-        $copyBtn.style.borderTopRightRadius = '0px'
-        $copyDropdown.style.right = `${scrollbarWidth - 2}px`
-    } else {
-        $element.style.paddingRight = ''
-        $btn.style.right = ''
-        $btn.style.borderTopRightRadius = ''
-        $dropdown.style.right = ''
-        $copyBtn.style.right = ''
-        $copyBtn.style.borderTopRightRadius = ''
-        $copyDropdown.style.right = ''
+    var MLTextarea = function(element, options) {
+        this.options = options
+        this.$el = $(element)
+        $.wn.foundation.controlUtils.markDisposable(element)
+        Base.call(this)
+        this.init()
     }
 
-}
+    MLTextarea.prototype = Object.create(BaseProto)
+    MLTextarea.prototype.constructor = MLTextarea
+
+    MLTextarea.DEFAULTS = {
+        autoTranslateHandler: null
+    }
+
+    MLTextarea.prototype.init = function() {
+        this.$el.multiLingual()
+
+        // Bind events
+        this.$textarea = $('textarea.form-control', this.$el)
+        this.$textarea.on('input', this.proxy(this.updateLayout))
+        this.$el.on('copyLocale.oc.multilingual', this.proxy(this.onCopyLocale))
+        this.$el.on('autoTranslateSuccess.oc.multilingual', this.proxy(this.onAutoTranslateSuccess))
+        this.$el.one('dispose-control', this.proxy(this.dispose))
+
+        // Initial layout update
+        this.updateLayout()
+    }
+
+    MLTextarea.prototype.dispose = function() {
+        if (this.$textarea) {
+            this.$textarea.off('input', this.proxy(this.updateLayout))
+        }
+        if (this.$el) {
+            this.$el.off('copyLocale.oc.multilingual', this.proxy(this.onCopyLocale))
+            this.$el.off('autoTranslateSuccess.oc.multilingual', this.proxy(this.onAutoTranslateSuccess))
+            this.$el.off('dispose-control', this.proxy(this.dispose))
+            this.$el.removeData('oc.mlTextarea')
+        }
+
+        this.$textarea = null
+        this.$el = null
+        this.options = null
+    }
+
+    MLTextarea.prototype.updateLayout = function() {
+        var $element = this.$textarea.get(0)
+        if (!$element) return
+
+        var $parent = $element.parentElement
+        var $btn = $parent.querySelector('.ml-btn[data-active-locale]')
+        var $dropdown = $parent.querySelector('.ml-dropdown-menu[data-locale-dropdown]')
+        var $copyBtn = $parent.querySelector('.ml-copy-btn')
+        var $copyDropdown = $parent.querySelector('.ml-copy-dropdown-menu')
+
+        // set ML button position
+        var elementHeight = $element.offsetHeight
+        var scrollHeight = $element.scrollHeight
+        var showScrollbar = (scrollHeight - elementHeight) > 0
+
+        if (showScrollbar) {
+            var scrollbarWidth = $element.offsetWidth - $element.clientWidth
+            $element.style.paddingRight = (scrollbarWidth + 23) + 'px'
+            $btn.style.right = (scrollbarWidth - 1) + 'px'
+            $btn.style.borderTopRightRadius = '0px'
+            $dropdown.style.right = (scrollbarWidth - 2) + 'px'
+            $copyBtn.style.right = (scrollbarWidth - 1) + 'px'
+            $copyBtn.style.borderTopRightRadius = '0px'
+            $copyDropdown.style.right = (scrollbarWidth - 2) + 'px'
+        } else {
+            $element.style.paddingRight = ''
+            $btn.style.right = ''
+            $btn.style.borderTopRightRadius = ''
+            $dropdown.style.right = ''
+            $copyBtn.style.right = ''
+            $copyBtn.style.borderTopRightRadius = ''
+            $copyDropdown.style.right = ''
+        }
+    }
+
+    MLTextarea.prototype.onCopyLocale = function(e, {copyFromLocale, copyFromValue, currentLocale, provider}) {
+        this.$el.multiLingual('autoTranslate', copyFromLocale, provider)
+    }
+
+    MLTextarea.prototype.onAutoTranslateSuccess = function(e, data) {
+        if (data.translatedValue && data.translatedLocale) {
+            var translatedValue = data.translatedValue[0]
+            this.$textarea.val(translatedValue).trigger('input')
+            this.$el.multiLingual('setLocaleValue', translatedValue, data.translatedLocale)
+        }
+    }
+
+    $.fn.mlTextarea = function(option) {
+        return this.each(function() {
+            var $this = $(this)
+            var data = $this.data('oc.mlTextarea')
+            var options = $.extend({}, MLTextarea.DEFAULTS, $this.data(), typeof option == 'object' && option)
+
+            if (!data) $this.data('oc.mlTextarea', (data = new MLTextarea(this, options)))
+            if (typeof option == 'string') data[option]()
+        })
+    }
+
+    $.fn.mlTextarea.Constructor = MLTextarea
+
+    $(document).render(function() {
+        $('[data-control="mltextarea"]').mlTextarea()
+    })
+
+}(window.jQuery);

--- a/formwidgets/mltextarea/partials/_mltextarea.htm
+++ b/formwidgets/mltextarea/partials/_mltextarea.htm
@@ -3,7 +3,7 @@
     <div class="form-control"><?= nl2br(e($field->value)) ?></div>
 <?php else: ?>
     <div
-        id="<?= $this->getId() ?>"
+        id="<?= $this->getId('mlControl') ?>"
         data-control="mltextarea"
         data-copy-confirm="<?= e(trans('winter.translate::lang.locale.copy_confirm')); ?>"
         data-default-locale="<?= $defaultLocale->code ?>"

--- a/formwidgets/mltextarea/partials/_mltextarea.htm
+++ b/formwidgets/mltextarea/partials/_mltextarea.htm
@@ -4,10 +4,11 @@
 <?php else: ?>
     <div
         id="<?= $this->getId() ?>"
-        data-control="multilingual"
+        data-control="mltextarea"
         data-copy-confirm="<?= e(trans('winter.translate::lang.locale.copy_confirm')); ?>"
         data-default-locale="<?= $defaultLocale->code ?>"
         data-placeholder-field="#<?= $field->getId('placeholderField') ?>"
+        data-auto-translate-handler="<?= $this->getEventHandler('onAutoTranslate') ?>"
         class="field-multilingual field-multilingual-textarea dropdown">
 
         <textarea
@@ -16,7 +17,6 @@
             placeholder="<?= e(trans($field->placeholder)) ?>"
             class="form-control field-textarea size-<?= $field->size ?>"
             autocomplete="off"
-            oninput="updateTextareaLayout(this)"
             <?= $field->getAttributes() ?>><?= e($field->value) ?></textarea>
 
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -38,7 +38,9 @@ return [
         'reorder_title' => 'Reorder languages',
         'sort_order' => 'Sort Order',
         'copy_from' => 'Copy from :locale',
-        'copy_confirm' => 'Are you sure you want to copy from another locale?',
+        'translate_method' => 'Translate Method',
+        'standard' => 'Standard',
+        'copy_button' => 'Copy',
     ],
     'messages' => [
         'title' => 'Translate messages',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -39,7 +39,7 @@ return [
         'sort_order' => 'Sort Order',
         'copy_from' => 'Copy from :locale',
         'translate_method' => 'Translate Method',
-        'standard' => 'Standard',
+        'none' => 'None',
         'copy_button' => 'Copy',
     ],
     'messages' => [

--- a/providers/DeepLTranslateProvider.php
+++ b/providers/DeepLTranslateProvider.php
@@ -2,7 +2,7 @@
 
 namespace Winter\Translate\Providers;
 
-use Winter\Translate\Contracts\TranslationProvider;
+use Winter\Translate\Providers\TranslationProvider;
 use Exception;
 use Illuminate\Support\Facades\Http;
 

--- a/providers/DeepLTranslateProvider.php
+++ b/providers/DeepLTranslateProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Winter\Translate\Providers;
+
+use Winter\Translate\Contracts\TranslationProvider;
+use Exception;
+use Illuminate\Support\Facades\Http;
+
+class DeepLTranslateProvider implements TranslationProvider
+{
+    protected array $config;
+
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    public function translate(array $input, string $targetLocale, string $currentLocale): array
+    {
+        $endpoint = rtrim($this->config['url'], '/');
+
+        $payload = [
+            'text' => $input,
+            'target_lang' => strtoupper($targetLocale),
+            'tag_handling' => 'html',
+            'source_lang' => strtoupper($currentLocale),
+        ];
+
+        $response = Http::withHeaders([
+            'Authorization' => "DeepL-Auth-Key {$this->config['key']}",
+            'Content-Type'  => 'application/json',
+        ])->post($endpoint, $payload);
+
+        if (!$response->successful()) {
+            throw new Exception("DeepL Translation failed: " . $response->body());
+        }
+
+        $json = $response->json();
+
+        return array_column($json['translations'], 'text');
+    }
+}

--- a/providers/GoogleTranslateProvider.php
+++ b/providers/GoogleTranslateProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Winter\Translate\Providers;
+
+use Winter\Translate\Contracts\TranslationProvider;
+use Exception;
+use Illuminate\Support\Facades\Http;
+
+class GoogleTranslateProvider implements TranslationProvider
+{
+    protected array $config;
+
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    public function translate(array $input, string $targetLocale, string $currentLocale): array
+    {
+        $query = http_build_query([
+            'target' => $targetLocale,
+            'source' => $currentLocale,
+            'key'    => $this->config['key'],
+        ]);
+
+        foreach ($input as $text) {
+            $query .= '&q=' . urlencode($text);
+        }
+
+        $endpoint = rtrim($this->config['url'], '/') . '?' . $query;
+
+        $response = Http::get($endpoint);
+
+        if (!$response->successful()) {
+            throw new Exception("Google Translation failed: " . $response->body());
+        }
+
+        $json = $response->json();
+
+        return array_map(fn($t) =>
+            urldecode(html_entity_decode($t['translatedText'], ENT_QUOTES | ENT_HTML5, 'UTF-8')),
+            $json['data']['translations']
+        );
+    }
+}

--- a/providers/GoogleTranslateProvider.php
+++ b/providers/GoogleTranslateProvider.php
@@ -2,7 +2,7 @@
 
 namespace Winter\Translate\Providers;
 
-use Winter\Translate\Contracts\TranslationProvider;
+use Winter\Translate\Providers\TranslationProvider;
 use Exception;
 use Illuminate\Support\Facades\Http;
 

--- a/providers/GoogleTranslateProvider.php
+++ b/providers/GoogleTranslateProvider.php
@@ -27,9 +27,9 @@ class GoogleTranslateProvider implements TranslationProvider
             $query .= '&q=' . urlencode($text);
         }
 
-        $endpoint = rtrim($this->config['url'], '/') . '?' . $query;
-
-        $response = Http::get($endpoint);
+        $endpoint = rtrim($this->config['url'], '/');
+        
+        $response = Http::withBody($query, 'application/x-www-form-urlencoded')->post($endpoint);
 
         if (!$response->successful()) {
             throw new Exception("Google Translation failed: " . $response->body());

--- a/providers/ProviderFactory.php
+++ b/providers/ProviderFactory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Winter\Translate;
+namespace Winter\Translate\Providers;
 
 use Illuminate\Support\Facades\Config;
 use Winter\Translate\Providers\GoogleTranslateProvider;
 use Winter\Translate\Providers\DeepLTranslateProvider;
-use Winter\Translate\Contracts\TranslationProvider;
+use Winter\Translate\Providers\TranslationProvider;
 
 class ProviderFactory
 {
@@ -17,10 +17,11 @@ class ProviderFactory
             throw new \Exception("No provider found: $provider");
         }
 
-        return match ($provider) {
-            'google' => new GoogleTranslateProvider($config),
-            'deepl'  => new DeepLTranslateProvider($config),
-            default  => throw new \Exception("No provider found: $provider"),
+
+        switch ($provider) {
+            case 'google': return new GoogleTranslateProvider($config); break;
+            case 'deepl': return new DeepLTranslateProvider($config); break;
+            default: throw new \Exception("No provider found: $provider"); break;
         };
     }
 }

--- a/providers/TranslationProvider.php
+++ b/providers/TranslationProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Winter\Translate\Contracts;
+namespace Winter\Translate\Providers;
 
 interface TranslationProvider
 {

--- a/tests/unit/traits/MLAutoTranslateTest.php
+++ b/tests/unit/traits/MLAutoTranslateTest.php
@@ -18,7 +18,6 @@ class MLAutoTranslateTest extends \Winter\Translate\Tests\TranslatePluginTestCas
     {
         $translator = $this->createTranslator();
 
-        Config::set('winter.translate::defaultProvider', 'google');
         Config::set('winter.translate::providers.google.url', 'https://fake-endpoint.com/translate');
         Config::set('winter.translate::providers.google.key', 'abc123');
 
@@ -34,7 +33,7 @@ class MLAutoTranslateTest extends \Winter\Translate\Tests\TranslatePluginTestCas
             ], 200)
         ]);
 
-        $result = $translator->translate(['Hola mundo'], 'en', 'es');
+        $result = $translator->translate(['Hola mundo'], 'en', 'es', 'google');
 
         $this->assertSame('Hello world', $result[0]);
     }
@@ -61,18 +60,6 @@ class MLAutoTranslateTest extends \Winter\Translate\Tests\TranslatePluginTestCas
         $result = $translator->translate(['Hola mundo'], 'en', 'es', 'google');
 
         $this->assertSame('Hello world', $result[0]);
-    }
-
-    public function test_get_provider_config_throws_if_provider_not_found()
-    {
-        $translator = $this->createTranslator();
-
-        Config::set('winter.translate::defaultProvider', 'missing');
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('No provider found: missing');
-
-        $translator->translate(['Foo'], 'en', 'es'); // uses default
     }
 
     public function test_get_provider_config_throws_if_named_provider_not_found()
@@ -135,16 +122,14 @@ class MLAutoTranslateTest extends \Winter\Translate\Tests\TranslatePluginTestCas
         $this->assertSame(['Hello world', 'Whats up?'], $result);
     }
 
-    public function test_it_throws_when_no_providers_exist()
+    public function test_it_throws_when_no_provider_is_provided()
     {
         $translator = $this->createTranslator();
 
-        Config::set('winter.translate::defaultProvider', 'missingProvider');
-
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('No provider found: missingProvider');
+        $this->expectExceptionMessage('Cannot translate without a provider');
 
-        $translator->translate(['Hello'], 'en', 'es');
+        $translator->translate(['Hello'], 'en', 'es', '');
     }
 
     public function test_it_throws_when_request_fails()

--- a/tests/unit/traits/MLAutoTranslateTest.php
+++ b/tests/unit/traits/MLAutoTranslateTest.php
@@ -188,6 +188,7 @@ class MLAutoTranslateTest extends \Winter\Translate\Tests\TranslatePluginTestCas
                             'does_not_work1' => '2',
                             'does_not_work2' => '3',
                             'does_not_work3' => '4',
+                            '1does_not_work4' => '5' // it should only translate keys with trailing numbers when defined in whitelist
                         ],
                     ],
                 ],
@@ -195,13 +196,13 @@ class MLAutoTranslateTest extends \Winter\Translate\Tests\TranslatePluginTestCas
             ],
 
             [
-                'value' => '5',
+                'value' => '6',
                 '_group' => 'block_single'
             ],
         ];
 
         $flattened = $translator->flatten($data, $whitelist);
-        $this->assertSame($flattened, ['0', '1', '5']);
+        $this->assertSame($flattened, ['0', '1', '2', '3', '4', '6']);
         $expanded = $translator->expand($flattened, $data, $whitelist);
         $this->assertSame($expanded, $data);
     }
@@ -240,7 +241,7 @@ class MLAutoTranslateTest extends \Winter\Translate\Tests\TranslatePluginTestCas
         ];
 
         $flattened = $translator->flatten($data, $whitelist);
-        $this->assertSame($flattened, ['0', '', '5']);
+        $this->assertSame($flattened, ['0', '', '2', '3', '4', '5']);
         $expanded = $translator->expand($flattened, $data, $whitelist);
         $this->assertSame($expanded, $data);
     }

--- a/tests/unit/traits/MLAutoTranslateTest.php
+++ b/tests/unit/traits/MLAutoTranslateTest.php
@@ -1,0 +1,293 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Config;
+use Winter\Translate\Traits\MLAutoTranslate;
+
+class MLAutoTranslateTest extends \Winter\Translate\Tests\TranslatePluginTestCase
+{
+
+    protected function createTranslator()
+    {
+        return new class {
+            use MLAutoTranslate;
+        };
+    }
+
+    public function test_get_provider_config_returns_default_provider()
+    {
+        $translator = $this->createTranslator();
+
+        Config::set('winter.translate::defaultProvider', 'google');
+        Config::set('winter.translate::providers.google.url', 'https://fake-endpoint.com/translate');
+        Config::set('winter.translate::providers.google.key', 'abc123');
+
+        Http::fake([
+            'https://fake-endpoint.com/*' => Http::response([
+                'data' => [
+                    'translations' => [
+                        [
+                            'translatedText' => 'Hello world'
+                        ]
+                    ]
+                ]
+            ], 200)
+        ]);
+
+        $result = $translator->translate(['Hola mundo'], 'en', 'es');
+
+        $this->assertSame('Hello world', $result[0]);
+    }
+
+    public function test_get_provider_config_returns_named_provider()
+    {
+        $translator = $this->createTranslator();
+
+        Config::set('winter.translate::providers.google.url', 'https://fake-endpoint.com/translate');
+        Config::set('winter.translate::providers.google.key', 'google-key');
+
+        Http::fake([
+            'https://fake-endpoint.com/*' => Http::response([
+                'data' => [
+                    'translations' => [
+                        [
+                            'translatedText' => 'Hello world'
+                        ]
+                    ]
+                ]
+            ], 200)
+        ]);
+
+        $result = $translator->translate(['Hola mundo'], 'en', 'es', 'google');
+
+        $this->assertSame('Hello world', $result[0]);
+    }
+
+    public function test_get_provider_config_throws_if_provider_not_found()
+    {
+        $translator = $this->createTranslator();
+
+        Config::set('winter.translate::defaultProvider', 'missing');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No provider found: missing');
+
+        $translator->translate(['Foo'], 'en', 'es'); // uses default
+    }
+
+    public function test_get_provider_config_throws_if_named_provider_not_found()
+    {
+        $translator = $this->createTranslator();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No provider found: ghost');
+
+        $translator->translate(['Foo'], 'en', 'es', 'ghost');
+    }
+
+    public function test_it_translates_via_provider()
+    {
+        $translator = $this->createTranslator();
+        Config::set('winter.translate::providers.google.url', 'https://fake-endpoint.com/translate');
+        Config::set('winter.translate::providers.google.key', 'fakekey');
+        Config::set('winter.translate::defaultProvider', 'google');
+
+        Http::fake([
+            'https://fake-endpoint.com/*' => Http::response([
+                'data' => [
+                    'translations' => [
+                        [
+                            'translatedText' => 'Hello world'
+                        ]
+                    ]
+                ]
+            ], 200)
+        ]);
+
+        $result = $translator->translate(['Hola mundo'], 'en', 'es', 'google');
+
+        $this->assertSame('Hello world', $result[0]);
+    }
+    public function test_it_translates_multiple_via_provider()
+    {
+        $translator = $this->createTranslator();
+        Config::set('winter.translate::providers.google.url', 'https://fake-endpoint.com/translate');
+        Config::set('winter.translate::providers.google.key', 'fakekey');
+        Config::set('winter.translate::defaultProvider', 'google');
+
+        Http::fake([
+            'https://fake-endpoint.com/*' => Http::response([
+                'data' => [
+                    'translations' => [
+                        [
+                            'translatedText' => 'Hello world'
+                        ],
+                        [
+                            'translatedText' => 'Whats up?'
+                        ]
+                    ]
+                ]
+            ], 200)
+        ]);
+
+        $result = $translator->translate(['Bonjour monde', 'Ca va?'], 'en', 'es', 'google');
+
+        $this->assertSame(['Hello world', 'Whats up?'], $result);
+    }
+
+    public function test_it_throws_when_no_providers_exist()
+    {
+        $translator = $this->createTranslator();
+
+        Config::set('winter.translate::defaultProvider', 'missingProvider');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No provider found: missingProvider');
+
+        $translator->translate(['Hello'], 'en', 'es');
+    }
+
+    public function test_it_throws_when_request_fails()
+    {
+        $translator = $this->createTranslator();
+        Config::set('winter.translate::providers.google.url', 'https://fake-endpoint.com/translate');
+        Config::set('winter.translate::providers.google.key', 'fakekey');
+        Config::set('winter.translate::defaultProvider', 'google');
+
+        Http::fake([
+            'https://fake-endpoint.com/*' => Http::response([
+                'error' => 'Something went wrong',
+            ], 500)
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Google Translation failed:');
+
+        $translator->translate(['Hola'], 'en', 'es', 'google');
+    }
+
+    public function test_flatten_and_expand_object()
+    {
+        $translator = $this->createTranslator();
+        $whitelist = [
+            'does_not_work',
+            'name',
+            'content',
+            'works',
+            'value',
+        ];
+
+        $data =  [
+            [
+                'is_delayed' => '0',
+                'trigger' => [
+                    [
+                        'works' => '0',
+                        'myForm' => [
+                            'does_not_work'  => '1',
+                            'does_not_work1' => '2',
+                            'does_not_work2' => '3',
+                            'does_not_work3' => '4',
+                        ],
+                    ],
+                ],
+                '_group' => 'block_complex',
+            ],
+
+            [
+                'value' => '5',
+                '_group' => 'block_single'
+            ],
+        ];
+
+        $flattened = $translator->flatten($data, $whitelist);
+        $this->assertSame($flattened, ['0', '1', '5']);
+        $expanded = $translator->expand($flattened, $data, $whitelist);
+        $this->assertSame($expanded, $data);
+    }
+    public function test_flatten_and_expand_object_sparse()
+    {
+        $translator = $this->createTranslator();
+        $whitelist = [
+            'does_not_work',
+            'name',
+            'content',
+            'works',
+            'value',
+        ];
+
+        $data =  [
+            [
+                'is_delayed' => '0',
+                'trigger' => [
+                    [
+                        'works' => '0',
+                        'myForm' => [
+                            'does_not_work'  => '',
+                            'does_not_work1' => '2',
+                            'does_not_work2' => '3',
+                            'does_not_work3' => '4',
+                        ],
+                    ],
+                ],
+                '_group' => 'block_complex',
+            ],
+
+            [
+                'value' => '5',
+                '_group' => 'block_single'
+            ],
+        ];
+
+        $flattened = $translator->flatten($data, $whitelist);
+        $this->assertSame($flattened, ['0', '', '5']);
+        $expanded = $translator->expand($flattened, $data, $whitelist);
+        $this->assertSame($expanded, $data);
+    }
+    public function test_flatten_and_expand_object_simple()
+    {
+        $translator = $this->createTranslator();
+        $whitelist = [
+            'does_not_work',
+            'name',
+            'content',
+            'works',
+            'value',
+        ];
+
+        $data = [
+            [
+                'data' => [
+                    'name'    => 'Bonjour',
+                    'content' => '',
+                ],
+            ],
+        ];
+
+        $flattened = $translator->flatten($data, $whitelist);
+        $this->assertSame($flattened, ['Bonjour', '']);
+        $expanded = $translator->expand($flattened, $data, $whitelist);
+        $this->assertSame($expanded, $data);
+    }
+    public function test_flatten_and_expand_array_simple()
+    {
+        $translator = $this->createTranslator();
+        $whitelist = [
+            'does_not_work',
+            'name',
+            'content',
+            'works',
+            'value',
+        ];
+
+        $data = [
+            'name'    => 'Bonjour',
+            'content' => 'Content',
+        ];
+
+        $flattened = $translator->flatten($data, $whitelist);
+        $this->assertSame($flattened, ['Bonjour', 'Content']);
+        $expanded = $translator->expand($flattened, $data, $whitelist);
+        $this->assertSame($expanded, $data);
+    }
+}

--- a/traits/MLAutoTranslate.php
+++ b/traits/MLAutoTranslate.php
@@ -142,13 +142,13 @@ trait MLAutoTranslate
     /**
      * @param string[] $input
      */
-    public function translate($input, string $targetLocale, string $currentLocale, string $provider = "")
+    public function translate($input, string $targetLocale, string $currentLocale, string $provider)
     {
         if (count($input) == 0) {
             throw new Exception("Cannot translate input of size 0");
         }
         if ($provider === '') {
-            $provider = Config::get('winter.translate::defaultProvider');
+            throw new Exception("Cannot translate without a provider");
         }
 
         $translator = ProviderFactory::create($provider);

--- a/traits/MLAutoTranslate.php
+++ b/traits/MLAutoTranslate.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Winter\Translate\Traits;
+/*
+* Used to intercept locale copy actions and auto translate
+* the response so it fits the target language
+*/
+
+use Exception;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Config;
+use Winter\Translate\ProviderFactory;
+
+trait MLAutoTranslate
+{
+
+    /**
+     * Flatten nested widgets into a list of whitelisted values, preserving order.
+     *
+     * @param array $items
+     * @param array $whitelist
+     * @return array
+     */
+    public function flatten(array $items, array $whitelist): array
+    {
+        $result = [];
+
+        $walk = function ($array) use (&$walk, &$result, $whitelist) {
+            foreach ($array as $key => $value) {
+                if (is_array($value)) {
+                    $walk($value);
+                } elseif (in_array($key, $whitelist, true)) {
+                    $result[] = $value;
+                }
+            }
+        };
+
+        $walk($items);
+        return $result;
+    }
+
+    /**
+     * Rebuild the original structure replacing only whitelisted values in original order.
+     *
+     * @param array $flatValues
+     * @param array $original
+     * @param array $whitelist
+     * @return array
+     */
+    public function expand(array $flatValues, array $original, array $whitelist): array
+    {
+        $idx = 0;
+
+        $replace = function (&$array) use (&$replace, &$idx, $flatValues, $whitelist) {
+            foreach ($array as $key => &$value) {
+                if (is_array($value)) {
+                    $replace($value);
+                } elseif (in_array($key, $whitelist, true)) {
+                    $value = $flatValues[$idx] ?? $value;
+                    $idx++;
+                }
+            }
+        };
+
+        $copy = $original;
+        $replace($copy);
+        return $copy;
+    }
+
+    public function autoTranslateArray($copyFromValues, $currentLocale, $copyFromLocale, $provider)
+    {
+        $whitelist = $this->getAutoTranslatableFields();
+        $flattenedValues = $this->flatten($copyFromValues, $whitelist);
+
+        $translatedValues = $this->translate(
+            $flattenedValues,
+            $currentLocale,
+            $copyFromLocale,
+            $provider
+        );
+
+        return $this->expand($translatedValues, $copyFromValues, $whitelist);
+    }
+
+    public function onAutoTranslate()
+    {
+        $copyFromLocale = post('_copy_from_locale');
+        $copyFromValue = post('_copy_from_value');
+        $currentLocale = post('_current_locale');
+        $provider = post('_provider');
+
+        if (!$copyFromLocale || !$currentLocale) {
+            throw new Exception("Missing locale selection");
+        }
+
+        if (!$copyFromValue) {
+            throw new Exception("Nothing to translate");
+        }
+
+        $translated = $this->translate(
+            [$copyFromValue],
+            $currentLocale,
+            $copyFromLocale,
+            $provider
+        );
+
+        return [
+            'translatedValue' => $translated,
+            'translatedLocale' => $currentLocale
+        ];
+    }
+    public function getProviderConfig($provider = "")
+    {
+
+        if ($provider == "") {
+            $provider = Config::get('winter.translate::defaultProvider');
+        }
+
+        $providerConfig = Config::get('winter.translate::providers.' . $provider);
+        if (!$providerConfig) {
+            throw new Exception("No config for provider: " . $provider);
+        }
+        return $providerConfig;
+    }
+
+    public function getAutoTranslatableFields()
+    {
+        return Config::get("winter.translate::autoTranslateWhiteList", []);
+    }
+
+    /**
+     * @param string[] $input
+     */
+    public function translate($input, string $targetLocale, string $currentLocale, string $provider = "")
+    {
+        if ($provider === '') {
+            $provider = Config::get('winter.translate::defaultProvider');
+        }
+
+        $translator = ProviderFactory::create($provider);
+
+        return $translator->translate($input, $targetLocale, $currentLocale);
+    }
+}

--- a/traits/MLControl.php
+++ b/traits/MLControl.php
@@ -5,6 +5,7 @@ namespace Winter\Translate\Traits;
 use Str;
 use Winter\Storm\Html\Helper as HtmlHelper;
 use Winter\Translate\Models\Locale;
+use Illuminate\Support\Facades\Config;
 
 /**
  * Generic ML Control
@@ -78,8 +79,7 @@ trait MLControl
             $this->originalViewPath = $this->viewPath;
             $this->assetPath = $this->getParentAssetPath();
             $this->viewPath = $this->getParentViewPath();
-        }
-        else {
+        } else {
             $this->assetPath = $this->originalAssetPath;
             $this->viewPath = $this->originalViewPath;
         }
@@ -125,6 +125,7 @@ trait MLControl
     {
         $this->vars['defaultLocale'] = $this->defaultLocale;
         $this->vars['locales'] = Locale::listAvailable();
+        $this->vars['providers'] = Config::get('winter.translate::providers');
         $this->vars['field'] = $this->makeRenderFormField();
     }
 
@@ -150,15 +151,13 @@ trait MLControl
          * Get the translated values from the model
          */
         $studKey = Str::studly(implode(' ', HtmlHelper::nameToArray($key)));
-        $mutateMethod = 'get'.$studKey.'AttributeTranslated';
+        $mutateMethod = 'get' . $studKey . 'AttributeTranslated';
 
         if ($this->objectMethodExists($this->model, $mutateMethod)) {
             $value = $this->model->$mutateMethod($locale);
-        }
-        elseif ($this->objectMethodExists($this->model, 'getAttributeTranslated') && $this->defaultLocale->code != $locale) {
+        } elseif ($this->objectMethodExists($this->model, 'getAttributeTranslated') && $this->defaultLocale->code != $locale) {
             $value = $this->model->setTranslatableUseFallback(false)->getAttributeTranslated($key, $locale);
-        }
-        else {
+        } else {
             $value = $this->formField->value;
         }
 
@@ -192,14 +191,13 @@ trait MLControl
          * Set the translated values to the model
          */
         $studKey = Str::studly(implode(' ', HtmlHelper::nameToArray($key)));
-        $mutateMethod = 'set'.$studKey.'AttributeTranslated';
+        $mutateMethod = 'set' . $studKey . 'AttributeTranslated';
 
         if ($this->objectMethodExists($this->model, $mutateMethod)) {
             foreach ($localeData as $locale => $value) {
                 $this->model->$mutateMethod($value, $locale);
             }
-        }
-        elseif ($this->objectMethodExists($this->model, 'setAttributeTranslated')) {
+        } elseif ($this->objectMethodExists($this->model, 'setAttributeTranslated')) {
             foreach ($localeData as $locale => $value) {
                 $this->model->setAttributeTranslated($key, $value, $locale);
             }

--- a/traits/MLControl.php
+++ b/traits/MLControl.php
@@ -279,4 +279,14 @@ trait MLControl
 
         return method_exists($object, $method);
     }
+    /**
+     * Handle the translation method selector popup request
+     */
+    public function onShowTranslationMethodSelector()
+    {
+        $this->vars['copy_from_locale'] = post('_copy_from_locale');
+        $this->vars['current_locale'] = post('_current_locale');
+        $this->prepareLocaleVars();
+        return $this->makeMLPartial('translation_method_popup');
+    }
 }

--- a/traits/MLControl.php
+++ b/traits/MLControl.php
@@ -126,6 +126,7 @@ trait MLControl
         $this->vars['defaultLocale'] = $this->defaultLocale;
         $this->vars['locales'] = Locale::listAvailable();
         $this->vars['providers'] = Config::get('winter.translate::providers');
+        $this->vars['defaultProvider'] = Config::get('winter.translate::defaultProvider');
         $this->vars['field'] = $this->makeRenderFormField();
     }
 

--- a/traits/mlcontrol/partials/_locale_copy.htm
+++ b/traits/mlcontrol/partials/_locale_copy.htm
@@ -28,26 +28,36 @@
                 <form>
                     <div class="form-group">
                         <fieldset>
-                            <h3>
+                            <h3 class="lang-code-display">
                                 <span data-display-locale></span>→<span data-display-active-locale></span>
                             </h3>
                             <p><?= e(trans('winter.translate::lang.locale.translate_method')); ?></p>
 
-                            <div class="radio custom-radio">
-                                <input checked="checked" name="translation_provider_<?= $widgetId ?>" value="standard"
-                                    type="radio" id="radio_standard_<?= $widgetId ?>" />
-                                <label for="radio_standard_<?= $widgetId ?>"><?= e(trans('winter.translate::lang.locale.standard')); ?></label>
-                            </div>
+                            <?php
+                                $default = strtolower($defaultProvider ?? '');
+                                $isStandard = ($default === '' || $default === 'standard');
 
-                            <?php foreach ($providers as $providerKey => $providerConfig): ?>
-                            <div class="radio custom-radio">
-                                <input name="translation_provider_<?= $widgetId ?>" value="<?= $providerKey ?>"
-                                    type="radio" id="radio_<?= $providerKey ?>_<?= $widgetId ?>" />
-                                <label for="radio_<?= $providerKey ?>_<?= $widgetId ?>">
-                                    <?= ucfirst($providerKey) ?>
-                                </label>
+                                // some FormWidgets are not machine translatable, eg. MediaFinder
+                                $translatable = $autoTranslatable ?? true;
+                            ?>
+
+                            <div class="form-group">
+                                <select name="translation_provider_<?= $widgetId ?>" class="form-control">
+
+                                    <option value="standard" <?= $isStandard ? 'selected' : '' ?>>
+                                        <?= e(trans('winter.translate::lang.locale.standard')); ?>
+                                    </option>
+
+                                    <?php if ($translatable) { ?>
+                                        <?php foreach ($providers as $providerName => $providerConfig): ?>
+                                            <?php $selected = ($default === strtolower($providerName)) ? 'selected' : ''; ?>
+                                            <option value="<?= $providerName ?>" <?= $selected ?>>
+                                                <?= ucfirst($providerName) ?>
+                                            </option>
+                                        <?php endforeach ?>
+                                    <?php } ?>
+                                </select>
                             </div>
-                            <?php endforeach ?>
 
                             <div class="modal-footer">
                                 <button data-selected-locale="" type="button" class="btn btn-primary"

--- a/traits/mlcontrol/partials/_locale_copy.htm
+++ b/traits/mlcontrol/partials/_locale_copy.htm
@@ -1,23 +1,63 @@
 <?php if (!config('winter.translate::disable_copy', false)): ?>
 <!-- Language Copy Dropdown -->
 <div class="dropdown ml-copy-dropdown">
-    <button
-        class="icon-copy btn ml-copy-btn"
-        data-toggle="dropdown"
-        type="button">
+    <button class="icon-copy btn ml-copy-btn" data-toggle="dropdown" type="button">
     </button>
     <ul class="dropdown-menu pull-right ml-copy-dropdown-menu" role="menu">
         <?php foreach ($locales as $code => $name): ?>
         <li role="presentation">
-            <a
-                role="menuitem"
-                tabindex="-1"
-                data-copy-locale="<?= $code ?>"
-                href="javascript:;">
+            <a role="menuitem" tabindex="-1" data-copy-locale="<?= $code ?>" href="javascript:;">
                 <?= e(trans('winter.translate::lang.locale.copy_from', ['locale' => $name])); ?>
             </a>
         </li>
         <?php endforeach ?>
     </ul>
+</div>
+
+<!-- NOTE: popup for choosing which method of translation -->
+<div class="control-popup modal ml-modal fade" tabindex="-1" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title"></h4>
+            </div>
+            <div class="modal-body">
+                <?php $widgetId = $this->getId(); ?>
+
+                <form>
+                    <div class="form-group">
+                        <fieldset>
+                            <h3>
+                                <span data-display-locale></span>→<span data-display-active-locale></span>
+                            </h3>
+                            <p><?= e(trans('winter.translate::lang.locale.translate_method')); ?></p>
+
+                            <div class="radio custom-radio">
+                                <input checked="checked" name="translation_provider_<?= $widgetId ?>" value="standard"
+                                    type="radio" id="radio_standard_<?= $widgetId ?>" />
+                                <label for="radio_standard_<?= $widgetId ?>"><?= e(trans('winter.translate::lang.locale.standard')); ?></label>
+                            </div>
+
+                            <?php foreach ($providers as $providerKey => $providerConfig): ?>
+                            <div class="radio custom-radio">
+                                <input name="translation_provider_<?= $widgetId ?>" value="<?= $providerKey ?>"
+                                    type="radio" id="radio_<?= $providerKey ?>_<?= $widgetId ?>" />
+                                <label for="radio_<?= $providerKey ?>_<?= $widgetId ?>">
+                                    <?= ucfirst($providerKey) ?>
+                                </label>
+                            </div>
+                            <?php endforeach ?>
+
+                            <div class="modal-footer">
+                                <button data-selected-locale="" type="button" class="btn btn-primary"
+                                    data-dismiss="modal"><?= e(trans('winter.translate::lang.locale.copy_button')); ?></button>
+                            </div>
+                        </fieldset>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
 </div>
 <?php endif; ?>

--- a/traits/mlcontrol/partials/_locale_copy.htm
+++ b/traits/mlcontrol/partials/_locale_copy.htm
@@ -35,7 +35,7 @@
 
                             <?php
                                 $default = strtolower($defaultProvider ?? '');
-                                $isStandard = ($default === '' || $default === 'standard');
+                                $isNone = ($default === '');
 
                                 // some FormWidgets are not machine translatable, eg. MediaFinder
                                 $translatable = $autoTranslatable ?? true;
@@ -44,8 +44,8 @@
                             <div class="form-group">
                                 <select name="translation_provider_<?= $widgetId ?>" class="form-control">
 
-                                    <option value="standard" <?= $isStandard ? 'selected' : '' ?>>
-                                        <?= e(trans('winter.translate::lang.locale.standard')); ?>
+                                    <option value="" <?= $isNone ? 'selected' : '' ?>>
+                                        <?= e(trans('winter.translate::lang.locale.none')); ?>
                                     </option>
 
                                     <?php if ($translatable) { ?>

--- a/traits/mlcontrol/partials/_locale_copy.htm
+++ b/traits/mlcontrol/partials/_locale_copy.htm
@@ -6,7 +6,13 @@
     <ul class="dropdown-menu pull-right ml-copy-dropdown-menu" role="menu">
         <?php foreach ($locales as $code => $name): ?>
         <li role="presentation">
-            <a role="menuitem" tabindex="-1" data-copy-locale="<?= $code ?>" href="javascript:;">
+            <a
+                role="menuitem"
+                tabindex="-1"
+                data-copy-open-handler="<?= $this->getEventHandler('onShowTranslationMethodSelector') ?>"
+                data-copy-locale="<?= $code ?>"
+                href="javascript:;"
+            >
                 <?= e(trans('winter.translate::lang.locale.copy_from', ['locale' => $name])); ?>
             </a>
         </li>
@@ -14,60 +20,4 @@
     </ul>
 </div>
 
-<!-- NOTE: popup for choosing which method of translation -->
-<div class="control-popup modal ml-modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title"></h4>
-            </div>
-            <div class="modal-body">
-                <?php $widgetId = $this->getId(); ?>
-
-                <form>
-                    <div class="form-group">
-                        <fieldset>
-                            <h3 class="lang-code-display">
-                                <span data-display-locale></span>→<span data-display-active-locale></span>
-                            </h3>
-                            <p><?= e(trans('winter.translate::lang.locale.translate_method')); ?></p>
-
-                            <?php
-                                $default = strtolower($defaultProvider ?? '');
-                                $isNone = ($default === '');
-
-                                // some FormWidgets are not machine translatable, eg. MediaFinder
-                                $translatable = $autoTranslatable ?? true;
-                            ?>
-
-                            <div class="form-group">
-                                <select name="translation_provider_<?= $widgetId ?>" class="form-control">
-
-                                    <option value="" <?= $isNone ? 'selected' : '' ?>>
-                                        <?= e(trans('winter.translate::lang.locale.none')); ?>
-                                    </option>
-
-                                    <?php if ($translatable) { ?>
-                                        <?php foreach ($providers as $providerName => $providerConfig): ?>
-                                            <?php $selected = ($default === strtolower($providerName)) ? 'selected' : ''; ?>
-                                            <option value="<?= $providerName ?>" <?= $selected ?>>
-                                                <?= ucfirst($providerName) ?>
-                                            </option>
-                                        <?php endforeach ?>
-                                    <?php } ?>
-                                </select>
-                            </div>
-
-                            <div class="modal-footer">
-                                <button data-selected-locale="" type="button" class="btn btn-primary"
-                                    data-dismiss="modal"><?= e(trans('winter.translate::lang.locale.copy_button')); ?></button>
-                            </div>
-                        </fieldset>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
-</div>
 <?php endif; ?>

--- a/traits/mlcontrol/partials/_translation_method_popup.htm
+++ b/traits/mlcontrol/partials/_translation_method_popup.htm
@@ -1,0 +1,48 @@
+<div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal" >&times;</button>
+    <h4 class="modal-title"></h4>
+</div>
+<div class="modal-body">
+    <?php $widgetId = $this->getId(); ?>
+    <h3 class="lang-code-display">
+        <span><?= $copy_from_locale ?></span>→<span><?= $current_locale ?></span>
+    </h3>
+    <p><?= e(trans('winter.translate::lang.locale.translate_method')); ?></p>
+
+    <?php
+    $default = strtolower($defaultProvider ?? '');
+    $isNone = ($default === '');
+
+    // some FormWidgets are not machine translatable, eg. MediaFinder
+    $translatable = $autoTranslatable ?? true;
+    ?>
+
+    <div class="form-group">
+        <select name="translation_provider_<?= $widgetId ?>" class="form-control">
+
+            <option value="" <?= $isNone ? 'selected' : '' ?>>
+                <?= e(trans('winter.translate::lang.locale.none')); ?>
+            </option>
+
+            <?php if ($translatable) { ?>
+            <?php foreach ($providers as $providerName => $providerConfig): ?>
+            <?php $selected = ($default === strtolower($providerName)) ? 'selected' : ''; ?>
+            <option value="<?= $providerName ?>" <?= $selected ?>>
+                <?= ucfirst($providerName) ?>
+            </option>
+            <?php endforeach ?>
+            <?php } ?>
+        </select>
+    </div>
+
+    <div class="modal-footer">
+        <button
+            data-widget-id="<?= $this->getId('mlControl') ?>"
+            data-selected-locale="<?= $copy_from_locale ?>"
+            type="button"
+            class="btn btn-primary"
+            data-dismiss="modal"
+        >
+            <?= e(trans('winter.translate::lang.locale.copy_button')); ?></button>
+    </div>
+</div>


### PR DESCRIPTION
#102

Created a trait that handles translation logic
Updated the copy flow to use a popup to confirm the copy and select provider.

The feature is working, but I would just appreciate some feedback on the UI and maybe the new APIs I made from the perspective of a developer using this plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added auto-translate support when copying content between locales, with a selectable translation provider (Google, DeepL) and a “none” option.
  * Integrated provider-based auto-translation into text, textarea, markdown, rich editor, repeaters, and blocks.
  * Added configuration for providers, default provider, and a whitelist of auto-translatable fields.

* **UI**
  * Added translation method/provider selector modal and improved provider label presentation.
  * Refined multilingual styling, including language code display and loading indicator layering; improved dropdown layout consistency.

* **Tests**
  * Added unit tests covering provider resolution, translation flows, and whitelist utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->