### PR TITLE
fix(tests): no message scan in test migrations

### DIFF
--- a/updates/v2.1.0/migrate_message_code.php
+++ b/updates/v2.1.0/migrate_message_code.php
@@ -12,6 +12,9 @@ class MigrateMessageCode extends Migration
 {
     const TABLE_NAME = 'winter_translate_messages';
 
+    /**
+     * Run the migrations.
+     */
     public function up()
     {
         if (!Schema::hasColumn(self::TABLE_NAME, 'code_pre_2_1_0')) {
@@ -48,6 +51,9 @@ class MigrateMessageCode extends Migration
         }
     }
 
+    /**
+     * Reverse the migrations.
+     */
     public function down()
     {
         if (!Schema::hasTable(self::TABLE_NAME)) {
@@ -69,6 +75,12 @@ class MigrateMessageCode extends Migration
         });
     }
 
+    /**
+     * Generate a legacy message code from the given message ID.
+     *
+     * @param string $messageId The message ID to convert.
+     * @return string The legacy message code.
+     */
     public static function makeLegacyMessageCode($messageId)
     {
         $separator = '.';

--- a/updates/v2.1.0/migrate_message_code.php
+++ b/updates/v2.1.0/migrate_message_code.php
@@ -77,11 +77,8 @@ class MigrateMessageCode extends Migration
 
     /**
      * Generate a legacy message code from the given message ID.
-     *
-     * @param string $messageId The message ID to convert.
-     * @return string The legacy message code.
      */
-    public static function makeLegacyMessageCode($messageId)
+    public static function makeLegacyMessageCode(string $messageId): string
     {
         $separator = '.';
 

--- a/updates/v2.1.0/migrate_message_code.php
+++ b/updates/v2.1.0/migrate_message_code.php
@@ -1,5 +1,6 @@
 <?php namespace Winter\Translate\Updates;
 
+use App;
 use Config;
 use Schema;
 use Str;
@@ -31,7 +32,7 @@ class MigrateMessageCode extends Migration
            });
         }
 
-        if (in_array('Cms', Config::get('cms.loadModules', []))) {
+        if (!App::runningUnitTests() && in_array('Cms', Config::get('cms.loadModules', []))) {
             ThemeScanner::scan();
         }
 


### PR DESCRIPTION
ThemeScanner::scan() should not be called during test migration, as tests assume the messages table starts empty. This prevents tests from failing in environments where the active theme contains scannable strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved migration robustness: avoid running theme scans during test runs and refine module-loading guards.
  * Enforced stricter input/output handling for a migration helper to reduce runtime issues.

* **Documentation**
  * Added descriptive docblocks to migration methods and helpers for clearer maintainer guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->