### PR TITLE
Restore previous behavior and add $defaultLocaleFallback argument

### DIFF
--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -83,6 +83,7 @@ class TranslatableModel extends TranslatableBehavior
         } elseif ($defaultLocaleFallback) {
             $query->where($index, $operator, $value);
         } else {
+            // return empty result set
             $query->whereRaw('1 = 0');
         }
 

--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -63,7 +63,7 @@ class TranslatableModel extends TranslatableBehavior
      * @param  string $locale
      * @return Builder
      */
-    public function scopeTransWhere($query, $index, $value, $locale = null, $operator = '=', $fallbackToBase = true)
+    public function scopeTransWhere($query, $index, $value, $locale = null, $operator = '=', $defaultLocaleFallback = false)
     {
         if (!$locale) {
             $locale = $this->translatableContext;

--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -63,7 +63,7 @@ class TranslatableModel extends TranslatableBehavior
      * @param  string $locale
      * @return Builder
      */
-    public function scopeTransWhere($query, $index, $value, $locale = null, $operator = '=')
+    public function scopeTransWhere($query, $index, $value, $locale = null, $operator = '=', $fallbackToBase = false)
     {
         if (!$locale) {
             $locale = $this->translatableContext;
@@ -80,8 +80,10 @@ class TranslatableModel extends TranslatableBehavior
 
         if ($translateIndexes->count()) {
             $query->whereIn($this->model->getQualifiedKeyName(), $translateIndexes);
-        } else {
+        } elseif ($fallbackToBase) {
             $query->where($index, $operator, $value);
+        } else {
+            $query->whereRaw('1 = 0');
         }
 
         return $query;

--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -80,7 +80,7 @@ class TranslatableModel extends TranslatableBehavior
 
         if ($translateIndexes->count()) {
             $query->whereIn($this->model->getQualifiedKeyName(), $translateIndexes);
-        } elseif ($fallbackToBase) {
+        } elseif ($defaultLocaleFallback) {
             $query->where($index, $operator, $value);
         } else {
             $query->whereRaw('1 = 0');

--- a/behaviors/TranslatableModel.php
+++ b/behaviors/TranslatableModel.php
@@ -63,7 +63,7 @@ class TranslatableModel extends TranslatableBehavior
      * @param  string $locale
      * @return Builder
      */
-    public function scopeTransWhere($query, $index, $value, $locale = null, $operator = '=', $fallbackToBase = false)
+    public function scopeTransWhere($query, $index, $value, $locale = null, $operator = '=', $fallbackToBase = true)
     {
         if (!$locale) {
             $locale = $this->translatableContext;


### PR DESCRIPTION
Avoids blog posts being available with a wrong URL:

- mysite.com/en/blog/hello
- mysite.com/fr/blog/bonjour
- mysite.com/fr/blog/hello <== Bug causing duplicate SEO content and the page shouldn't really exist
