### PR TITLE
Refactor Message model to centralize column definitions

### DIFF
--- a/controllers/Messages.php
+++ b/controllers/Messages.php
@@ -13,6 +13,7 @@ use Winter\Translate\Classes\ThemeScanner;
 use Winter\Translate\Models\Locale;
 use Winter\Translate\Models\Message;
 use Winter\Translate\Models\MessageExport;
+use Winter\Translate\Models\MessageImport;
 
 /**
  * Messages Backend Controller
@@ -37,7 +38,7 @@ class Messages extends Controller
         $this->addJs('/plugins/winter/translate/assets/js/messages.js');
         $this->addCss('/plugins/winter/translate/assets/css/messages.css');
 
-        $this->importColumns = MessageExport::getColumns();
+        $this->importColumns = MessageImport::getColumns();
         $this->exportColumns = MessageExport::getColumns();
     }
 

--- a/models/Message.php
+++ b/models/Message.php
@@ -13,6 +13,8 @@ use Model;
 class Message extends Model
 {
     const DEFAULT_LOCALE = 'x';
+    const CODE_COLUMN_NAME = 'code';
+    const DEFAULT_COLUMN_NAME = 'default';
 
     /**
      * @var string The database table used by the model.
@@ -297,5 +299,17 @@ class Message extends Model
     public static function makeMessageCode($message)
     {
         return md5(trim($message));
+    }
+
+    /**
+     * Returns base/common columns for import/export: code + default locale + all existing locales.
+     * These are the default columns, but specific procedures (ex: export) may add or remove columns.
+     */
+    public static function getColumns(): array
+    {
+        return array_merge([
+            self::CODE_COLUMN_NAME => self::CODE_COLUMN_NAME,
+            self::DEFAULT_LOCALE => self::DEFAULT_COLUMN_NAME,
+        ], Locale::lists(self::CODE_COLUMN_NAME, self::CODE_COLUMN_NAME));
     }
 }

--- a/models/MessageExport.php
+++ b/models/MessageExport.php
@@ -27,7 +27,7 @@ class MessageExport extends ExportModel
      * name      | Name      | Name  | Name  | Prénom| 0
      * ...
      */
-    public function exportData(array $columns, ?string $sessionKey = null): array
+    public function exportData($columns, $sessionKey = null)
     {
         return Message::all()->map(function ($message) use ($columns) {
             $data = $message->message_data ?: [];

--- a/models/MessageExport.php
+++ b/models/MessageExport.php
@@ -6,49 +6,47 @@ use Backend\Models\ExportModel;
 
 class MessageExport extends ExportModel
 {
-    const CODE_COLUMN_NAME = 'code';
-    const DEFAULT_COLUMN_NAME = 'default';
+    /*
+     * @deprecated since version 2.3.2, use \Winter\Translate\Models\Message::CODE_COLUMN_NAME directly
+     * @see \Winter\Translate\Models\Message::CODE_COLUMN_NAME
+     */
+    const CODE_COLUMN_NAME = \Winter\Translate\Models\Message::CODE_COLUMN_NAME;
+
+    /*
+     * @deprecated since version 2.3.2, use \Winter\Translate\Models\Message::DEFAULT_COLUMN_NAME directly
+     * @see \Winter\Translate\Models\Message::DEFAULT_COLUMN_NAME
+     */
+    const DEFAULT_COLUMN_NAME = \Winter\Translate\Models\Message::DEFAULT_COLUMN_NAME;
 
     /**
      * Exports the message data with each locale in a separate column.
      *
-     * code      | default   | en    | de    | fr
-     * ----------------------------------------------
-     * title     | Title     | Title | Titel | Titre
-     * name      | Name      | Name  | Name  | Prénom
+     * code      | default   | en    | de    | fr    | found
+     * --------------------------------------------------
+     * title     | Title     | Title | Titel | Titre | 1
+     * name      | Name      | Name  | Name  | Prénom| 0
      * ...
-     *
-     * @param $columns
-     * @param null $sessionKey
-     * @return mixed
      */
-    public function exportData($columns, $sessionKey = null)
+    public function exportData(array $columns, ?string $sessionKey = null): array
     {
         return Message::all()->map(function ($message) use ($columns) {
             $data = $message->message_data;
-            // Add code to data to simplify algorithm
-            $data[self::CODE_COLUMN_NAME] = $message->code;
 
             $result = [];
             foreach ($columns as $column) {
-                $result[$column] = isset($data[$column]) ? $data[$column] : '';
+                $result[$column] = array_key_exists($column, $data)
+                    ? $data[$column]
+                    : ($message->$column ?? '');
             }
             return $result;
         })->toArray();
     }
 
     /**
-     * getColumns
-     *
-     * code, default column + all existing locales
-     *
-     * @return array
+     * Returns columns for export (import columns + 'found' flag)
      */
-    public static function getColumns()
+    public static function getColumns(): array
     {
-        return array_merge([
-            self::CODE_COLUMN_NAME => self::CODE_COLUMN_NAME,
-            Message::DEFAULT_LOCALE => self::DEFAULT_COLUMN_NAME,
-        ], Locale::lists(self::CODE_COLUMN_NAME, self::CODE_COLUMN_NAME));
+        return Message::getColumns() + ['found' => 'found'];
     }
 }

--- a/models/MessageExport.php
+++ b/models/MessageExport.php
@@ -30,7 +30,7 @@ class MessageExport extends ExportModel
     public function exportData(array $columns, ?string $sessionKey = null): array
     {
         return Message::all()->map(function ($message) use ($columns) {
-            $data = $message->message_data;
+            $data = $message->message_data ?: [];
 
             $result = [];
             foreach ($columns as $column) {

--- a/models/MessageExport.php
+++ b/models/MessageExport.php
@@ -6,13 +6,13 @@ use Backend\Models\ExportModel;
 
 class MessageExport extends ExportModel
 {
-    /*
+    /**
      * @deprecated since version 2.3.2, use \Winter\Translate\Models\Message::CODE_COLUMN_NAME directly
      * @see \Winter\Translate\Models\Message::CODE_COLUMN_NAME
      */
     const CODE_COLUMN_NAME = \Winter\Translate\Models\Message::CODE_COLUMN_NAME;
 
-    /*
+    /**
      * @deprecated since version 2.3.2, use \Winter\Translate\Models\Message::DEFAULT_COLUMN_NAME directly
      * @see \Winter\Translate\Models\Message::DEFAULT_COLUMN_NAME
      */
@@ -43,7 +43,9 @@ class MessageExport extends ExportModel
     }
 
     /**
-     * Returns columns for export (import columns + 'found' flag)
+     * Returns columns for export. These are the importable columns from Message::getColumns()
+     * plus an export-only metadata flag named 'found' that is included for human review
+     * and intentionally excluded from import because it is recalculated on import.
      */
     public static function getColumns(): array
     {

--- a/models/MessageImport.php
+++ b/models/MessageImport.php
@@ -34,7 +34,7 @@ class MessageImport extends ImportModel
      * messages by just adding the new codes and messages to the csv.
      *
      */
-    public function importData(array $results, ?string $sessionKey = null): void
+    public function importData($results, $sessionKey = null)
     {
         $codeName = Message::CODE_COLUMN_NAME;
         $defaultName = Message::DEFAULT_LOCALE;

--- a/models/MessageImport.php
+++ b/models/MessageImport.php
@@ -11,6 +11,14 @@ class MessageImport extends ImportModel
     ];
 
     /**
+     * Returns columns for import
+     */
+    public static function getColumns(): array
+    {
+        return Message::getColumns();
+    }
+
+    /**
      * Import the message data from a csv with the following schema:
      *
      * code  | en    | de    | fr
@@ -25,12 +33,10 @@ class MessageImport extends ImportModel
      * doesn't contain this code. As a result you can incrementally update the
      * messages by just adding the new codes and messages to the csv.
      *
-     * @param $results
-     * @param null $sessionKey
      */
-    public function importData($results, $sessionKey = null)
+    public function importData(array $results, ?string $sessionKey = null): void
     {
-        $codeName = MessageExport::CODE_COLUMN_NAME;
+        $codeName = Message::CODE_COLUMN_NAME;
         $defaultName = Message::DEFAULT_LOCALE;
 
         foreach ($results as $index => $result) {

--- a/tests/unit/models/ExportMessageTest.php
+++ b/tests/unit/models/ExportMessageTest.php
@@ -88,10 +88,11 @@ class ExportMessageTest extends \Winter\Translate\Tests\TranslatePluginTestCase
         $columns = MessageExport::getColumns();
 
         $this->assertEquals([
-            MessageExport::CODE_COLUMN_NAME => MessageExport::CODE_COLUMN_NAME,
-            Message::DEFAULT_LOCALE => MessageExport::DEFAULT_COLUMN_NAME,
+            Message::CODE_COLUMN_NAME => Message::CODE_COLUMN_NAME,
+            Message::DEFAULT_LOCALE => Message::DEFAULT_COLUMN_NAME,
             'en' => 'en',
             'de' => 'de',
+            'found' => 'found',
         ], $columns);
     }
 }


### PR DESCRIPTION
- Move CODE_COLUMN_NAME and DEFAULT_COLUMN_NAME constants from MessageExport to Message model, leaving deprecated alias for backward compatibility
- Add shared getColumns() method to Message for reuse
- Update MessageImport to use the shared columns
- Update MessageExport to use the shared columns, plus "found"

The last point is particularly important to avoid losing the "found" data in the export for human review, but it is unnecessary in the import since the system recalculates it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized message import/export column configuration.
  * Added a "found" column to message exports.

* **Bug Fixes**
  * More consistent export output with safer fallbacks when values are missing.

* **Chores**
  * Marked legacy export column identifiers as deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->