### PR TITLE
Preserve nested datatable values on ML locale switch/copy (#33)

### DIFF
--- a/formwidgets/MLBlocks.php
+++ b/formwidgets/MLBlocks.php
@@ -29,6 +29,7 @@ class MLBlocks extends Blocks
      */
     public function init()
     {
+        $this->registerLocaleDatatableHandlers();
         parent::init();
         $this->initLocale();
     }

--- a/formwidgets/MLNestedForm.php
+++ b/formwidgets/MLNestedForm.php
@@ -26,6 +26,7 @@ class MLNestedForm extends NestedForm
      */
     public function init()
     {
+        $this->registerLocaleDatatableHandlers();
         parent::init();
         $this->initLocale();
     }

--- a/formwidgets/MLRepeater.php
+++ b/formwidgets/MLRepeater.php
@@ -29,6 +29,7 @@ class MLRepeater extends Repeater
      */
     public function init()
     {
+        $this->registerLocaleDatatableHandlers();
         parent::init();
         $this->initLocale();
     }

--- a/tests/unit/traits/MLControlDatatableHandlersTest.php
+++ b/tests/unit/traits/MLControlDatatableHandlersTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Winter\Translate\Traits\MLControl;
+
+/**
+ * Covers the datatable postback-handler injection that keeps a datatable's client-memory
+ * data from being lost when an enclosing multilingual widget switches locale.
+ *
+ * @see https://github.com/wintercms/wn-translate-plugin/issues/33
+ */
+class MLControlDatatableHandlersTest extends \Winter\Translate\Tests\TranslatePluginTestCase
+{
+    protected function makeControl()
+    {
+        return new class {
+            use MLControl;
+
+            // Expose the protected helpers for testing.
+            public function apply(array $fields, array $handlers): array
+            {
+                return $this->applyLocaleDatatableHandlers($fields, $handlers);
+            }
+        };
+    }
+
+    public function test_injects_handlers_into_a_datatable_field()
+    {
+        $handlers = ['w::onSwitchItemLocale', 'w::onCopyItemLocale'];
+
+        $out = $this->makeControl()->apply([
+            'title' => ['type' => 'text'],
+            'specs' => ['type' => 'datatable'],
+        ], $handlers);
+
+        // Non-datatable field is untouched.
+        $this->assertArrayNotHasKey('postbackHandlerName', $out['title']);
+
+        // Datatable field gains the handlers, keeping the default onSave.
+        $names = explode(',', $out['specs']['postbackHandlerName']);
+        $this->assertContains('onSave', $names);
+        $this->assertContains('w::onSwitchItemLocale', $names);
+        $this->assertContains('w::onCopyItemLocale', $names);
+    }
+
+    public function test_preserves_and_dedupes_existing_handlers()
+    {
+        $out = $this->makeControl()->apply([
+            'specs' => ['type' => 'datatable', 'postbackHandlerName' => 'onSave,onCustom'],
+        ], ['w::onSwitchItemLocale', 'onCustom']);
+
+        $names = explode(',', $out['specs']['postbackHandlerName']);
+        $this->assertSame(['onSave', 'onCustom', 'w::onSwitchItemLocale'], $names);
+    }
+
+    public function test_injects_into_nested_form_datatables()
+    {
+        $handlers = ['w::onSwitchItemLocale', 'w::onCopyItemLocale'];
+
+        $out = $this->makeControl()->apply([
+            'contacts' => [
+                'type' => 'nestedform',
+                'form' => ['fields' => [
+                    'inner_specs' => ['type' => 'datatable'],
+                    'inner_text' => ['type' => 'text'],
+                ]],
+            ],
+        ], $handlers);
+
+        $inner = $out['contacts']['form']['fields'];
+        $this->assertStringContainsString('w::onSwitchItemLocale', $inner['inner_specs']['postbackHandlerName']);
+        $this->assertArrayNotHasKey('postbackHandlerName', $inner['inner_text']);
+    }
+}

--- a/traits/MLControl.php
+++ b/traits/MLControl.php
@@ -280,4 +280,125 @@ trait MLControl
 
         return method_exists($object, $method);
     }
+
+    /**
+     * Ensures any datatable form widget nested inside this multilingual widget posts
+     * its client-memory data during the locale switch/copy AJAX requests, not only on
+     * the form's save handler. Without this the datatable's values are dropped when the
+     * locale changes, since the Table widget only serialises its data for handlers
+     * listed in its `postbackHandlerName` (default `onSave`).
+     *
+     * This injects this widget's namespaced `onSwitchItemLocale` / `onCopyItemLocale`
+     * handlers into the `postbackHandlerName` of every nested datatable field, relying
+     * on the Table widget's list support (winter/winter#560).
+     *
+     * Must run before the inner form is built (i.e. before parent::init()).
+     *
+     * @see https://github.com/wintercms/wn-translate-plugin/issues/33
+     * @return void
+     */
+    protected function registerLocaleDatatableHandlers()
+    {
+        if (!isset($this->config)) {
+            return;
+        }
+
+        $handlers = [
+            $this->getEventHandler('onSwitchItemLocale'),
+            $this->getEventHandler('onCopyItemLocale'),
+        ];
+
+        if (isset($this->config->form)) {
+            $this->config->form = $this->addLocaleDatatableHandlers(
+                $this->normalizeFormConfig($this->config->form),
+                $handlers
+            );
+        }
+
+        if (isset($this->config->groups)) {
+            $groups = $this->normalizeFormConfig($this->config->groups);
+            foreach ($groups as $code => $group) {
+                if (is_array($group)) {
+                    $groups[$code] = $this->addLocaleDatatableHandlers($group, $handlers);
+                }
+            }
+            $this->config->groups = $groups;
+        }
+    }
+
+    /**
+     * Resolves a form/groups config (inline array, config object, or `$/path` reference)
+     * into a plain array so its field definitions can be inspected and modified.
+     *
+     * @param mixed $config
+     * @return array
+     */
+    protected function normalizeFormConfig($config)
+    {
+        if (is_string($config) && $config !== '') {
+            $config = $this->makeConfig($config);
+        }
+
+        if (is_object($config)) {
+            $config = json_decode(json_encode($config), true);
+        }
+
+        return is_array($config) ? $config : [];
+    }
+
+    /**
+     * Appends the given AJAX handlers to the `postbackHandlerName` of every datatable
+     * field within a form config, descending into nested form definitions.
+     *
+     * @param array $form
+     * @param string[] $handlers
+     * @return array
+     */
+    protected function addLocaleDatatableHandlers(array $form, array $handlers)
+    {
+        if (isset($form['fields']) && is_array($form['fields'])) {
+            $form['fields'] = $this->applyLocaleDatatableHandlers($form['fields'], $handlers);
+        }
+
+        foreach (['tabs', 'secondaryTabs'] as $tabKey) {
+            if (isset($form[$tabKey]['fields']) && is_array($form[$tabKey]['fields'])) {
+                $form[$tabKey]['fields'] = $this->applyLocaleDatatableHandlers($form[$tabKey]['fields'], $handlers);
+            }
+        }
+
+        return $form;
+    }
+
+    /**
+     * @param array $fields
+     * @param string[] $handlers
+     * @return array
+     */
+    protected function applyLocaleDatatableHandlers(array $fields, array $handlers)
+    {
+        foreach ($fields as $name => $config) {
+            if (!is_array($config)) {
+                continue;
+            }
+
+            if (($config['type'] ?? null) === 'datatable') {
+                $existing = $config['postbackHandlerName'] ?? 'onSave';
+                $list = is_array($existing)
+                    ? $existing
+                    : array_map('trim', explode(',', (string) $existing));
+                $config['postbackHandlerName'] = implode(',', array_values(array_unique(
+                    array_merge(array_filter($list), $handlers)
+                )));
+            }
+
+            // Descend into nested form definitions (nested form / repeater sub-fields).
+            if (isset($config['form']) && is_array($config['form'])) {
+                $config['form'] = $this->addLocaleDatatableHandlers($config['form'], $handlers);
+            }
+
+            $fields[$name] = $config;
+        }
+
+        return $fields;
+    }
 }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -151,3 +151,4 @@
 "2.3.0": "Make use of controller behavior default views present in Winter v1.2.8+."
 "2.3.1": "Add ability to copy content from one language to another to simplify the translation process"
 "2.3.2": "Refactor Message model with shared column definitions"
+"2.3.3": "Preserve datatable values inside translatable repeaters/nested forms when switching or copying locales (#33)"


### PR DESCRIPTION
## Problem

Fixes #33.

A `datatable` form widget inside a translatable **repeater / nested form** loses its values when the locale is switched. The Table widget only serialises its client-memory data for AJAX handlers listed in its `postbackHandlerName` (default `onSave`), but the ML widgets switch/copy locales via `onSwitchItemLocale` / `onCopyItemLocale`. So the datatable's data is never posted on those requests, and the previous locale's copy is stored without it — dropping the values.

winter/wn-translate-plugin#560 added `postbackHandlerName` **list** support to the Table widget, which is the mechanism to fix this — but nothing wired the ML widgets' (dynamically namespaced) switch/copy handlers into nested datatables, so out of the box the loss still happened.

## Fix

`MLRepeater`, `MLNestedForm` and `MLBlocks` now inject their own namespaced `onSwitchItemLocale` + `onCopyItemLocale` handlers into the `postbackHandlerName` of every nested `datatable` field before the inner form is built. Existing handlers (incl. the default `onSave`) are preserved and de-duplicated. No per-field configuration is required.

Implemented as a small shared helper on the `MLControl` trait, called from each widget's `init()` before `parent::init()`.

## Tests

- **Unit** (`tests/unit/traits/MLControlDatatableHandlersTest.php`): the injection adds both handlers to datatable fields (keeping `onSave`), de-dupes existing handlers, descends into nested-form datatables, and leaves non-datatable fields untouched.
- **Manual, in-browser**: a datatable seeded in a translatable repeater survives an EN → nl-BE → EN locale round-trip with the fix (values preserved), where it was emptied without it.

## Notes

Requires the Table widget's `postbackHandlerName` list support from winter/winter#560 (already on `develop`/`main`). Datatables inside the `blocks` widget aren't covered yet — their field definitions come from the block registry rather than the widget's `form`/`groups` config; can follow up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved datatable values in translatable repeaters and nested forms when switching or copying locales.
  * Improved multilingual form handling across nested forms, tabs, groups, and repeaters.
  * Existing datatable handlers are now retained without duplication.
* **Tests**
  * Added coverage for multilingual datatable behavior, including nested forms and existing handler configurations.
* **Chores**
  * Updated the release version to 2.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->