### PR TITLE
Fix translatable-field collection for repeater groups and tab-organized nested forms

### DIFF
--- a/tests/unit/traits/MLAutoTranslateTest.php
+++ b/tests/unit/traits/MLAutoTranslateTest.php
@@ -273,6 +273,61 @@ class MLAutoTranslateTest extends \Winter\Translate\Tests\TranslatePluginTestCas
         $this->assertSame(['caption', 'heading'], $fields);
     }
 
+    public function test_get_auto_translatable_fields_collects_groups_sharing_field_names()
+    {
+        // Groups routinely reuse the same field name (e.g. a shared `data`
+        // nestedform); each group must be scanned separately so later groups
+        // are not dropped by a keyed merge.
+        $translator = $this->createTranslator([
+            'useGroups' => true,
+            'groupDefinitions' => [
+                'block_a' => ['fields' => [
+                    'data' => [
+                        'type' => 'nestedform',
+                        'form' => ['fields' => [
+                            'heading' => ['type' => 'text', 'translatable' => true],
+                        ]],
+                    ],
+                ]],
+                'block_b' => ['fields' => [
+                    'data' => [
+                        'type' => 'nestedform',
+                        'form' => ['fields' => [
+                            'caption' => ['type' => 'text', 'translatable' => true],
+                        ]],
+                    ],
+                ]],
+            ],
+        ]);
+
+        $fields = $translator->getAutoTranslatableFields();
+        sort($fields);
+        $this->assertSame(['caption', 'heading'], $fields);
+    }
+
+    public function test_get_auto_translatable_fields_collects_tab_organized_nested_forms()
+    {
+        // A nested form may organize its fields under form.tabs.fields /
+        // form.secondaryTabs.fields instead of form.fields.
+        $translator = $this->createTranslator(['form' => ['fields' => [
+            'data' => [
+                'type' => 'nestedform',
+                'form' => [
+                    'tabs' => ['fields' => [
+                        'heading' => ['type' => 'text', 'translatable' => true],
+                    ]],
+                    'secondaryTabs' => ['fields' => [
+                        'caption' => ['type' => 'text', 'translatable' => true],
+                    ]],
+                ],
+            ],
+        ]]]);
+
+        $fields = $translator->getAutoTranslatableFields();
+        sort($fields);
+        $this->assertSame(['caption', 'heading'], $fields);
+    }
+
     public function test_flatten_and_expand_object()
     {
         $translator = $this->createTranslator();

--- a/traits/MLAutoTranslate.php
+++ b/traits/MLAutoTranslate.php
@@ -137,7 +137,17 @@ trait MLAutoTranslate
     public function getAutoTranslatableFields(): array
     {
         $names = [];
-        $this->collectTranslatableFieldNames($this->getTranslatableFieldDefinitions(), $names);
+
+        // Repeater / Blocks group mode: scan every group separately — groups
+        // routinely reuse the same field names (e.g. a shared `data` nestedform),
+        // so merging their fields by key would drop all but the first group.
+        if (!empty($this->useGroups) && !empty($this->groupDefinitions)) {
+            foreach ($this->groupDefinitions as $group) {
+                $this->collectTranslatableFieldNames((array) array_get($group, 'fields', []), $names);
+            }
+        } else {
+            $this->collectTranslatableFieldNames($this->getTranslatableFieldDefinitions(), $names);
+        }
 
         return array_values(array_unique($names));
     }
@@ -145,23 +155,14 @@ trait MLAutoTranslate
     /**
      * Returns the form field definitions to scan for `translatable: true`.
      *
-     * Handles the two shapes used by the composite ML widgets: group mode
-     * (repeater with `groups:` / blocks) and a single `form:` definition
-     * (repeater / nestedform). Non-widget consumers get an empty set.
+     * Handles the single `form:` definition shape (repeater / nestedform);
+     * group mode is handled in getAutoTranslatableFields. Non-widget
+     * consumers get an empty set.
      *
      * @return array
      */
     protected function getTranslatableFieldDefinitions(): array
     {
-        // Repeater / Blocks group mode: merge the fields of every group.
-        if (!empty($this->useGroups) && !empty($this->groupDefinitions)) {
-            $fields = [];
-            foreach ($this->groupDefinitions as $group) {
-                $fields += (array) array_get($group, 'fields', []);
-            }
-            return $fields;
-        }
-
         // Single form definition (repeater / nestedform).
         if (isset($this->form)) {
             return $this->resolveConfigFields($this->form);
@@ -239,7 +240,14 @@ trait MLAutoTranslate
             }
 
             // Descend into nested composite widgets (repeater / nestedform).
-            foreach (['form.fields', 'fields', 'tabs.fields', 'secondaryTabs.fields'] as $childPath) {
+            foreach ([
+                'form.fields',
+                'form.tabs.fields',
+                'form.secondaryTabs.fields',
+                'fields',
+                'tabs.fields',
+                'secondaryTabs.fields',
+            ] as $childPath) {
                 $this->collectTranslatableFieldNames(array_get($config, $childPath, []), $names);
             }
 


### PR DESCRIPTION
Found while production-testing this branch as requested in #115. Two issues stopped `translatable: true` fields from being picked up with real-world field definitions:

1. **Repeater/blocks groups sharing a field name lose all but the first group.** `getAutoTranslatableFields()` merged group fields with a keyed union (`+=`). Block groups routinely all wrap their content in an identically-named nestedform (e.g. `data`), so only the first group's fields were scanned and every other block silently fell back to plain copy. Groups are now scanned separately.
2. **`form.tabs.fields` / `form.secondaryTabs.fields` were not descended into**, so nested forms that organize fields in tabs never had their fields collected.

Both verified end-to-end on our production field definitions (blocks repeater, `nl-BE` → `en` via Google) and covered by regression tests (suite green: 18 tests, 27 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)