### PR TITLE
Add shortcuts for auto-translate mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ Every multilingual backend field has a "copy from another locale" action. When a
 
 Note: if the SHIFT key is pressed while clicking the copy icon, the "translation method" picker will be skipped if there is a default provider setup or if there is a single provider configured.
 
+Note: if the CTRL key is pressed while clicking the copy icon, the locale value is copied without translation
+      (same as selecting None as the translation provider).
+
 ### Configuring a provider
 
 The easiest way is the backend settings screen: **Settings → Translation Providers**. It has a guided tab for each provider with step-by-step instructions (and direct links to each provider's console) beside a masked field for the API key:

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Every multilingual backend field has a "copy from another locale" action. When a
 
 **This is opt-in and invisible by default:** with no provider configured, the copy action stays a plain one-click copy — no provider popup, no extra UI. As soon as a provider key is set, a small "translation method" picker appears so the user can choose *None*, *Google* or *DeepL* when copying.
 
+Note: if the SHIFT key is pressed while clicking the copy icon, the "translation method" picker will be skipped if there is a default provider setup or if there is a single provider configured.
+
 ### Configuring a provider
 
 The easiest way is the backend settings screen: **Settings → Translation Providers**. It has a guided tab for each provider with step-by-step instructions (and direct links to each provider's console) beside a masked field for the API key:

--- a/assets/js/multilingual.js
+++ b/assets/js/multilingual.js
@@ -60,6 +60,10 @@
                 self.copyLocale(copyFromLocale, defaultProvider)
                 return
             }
+            if (event.ctrlKey) {
+                self.copyLocale(copyFromLocale, "")
+                return
+            }
             self.$el.on('complete.oc.popup', function (e, $source, $popup) {
                 const $button = $popup.find(`[data-widget-id="${self.$el.attr('id')}"]`)
                 $button.on('click', function(event) {

--- a/assets/js/multilingual.js
+++ b/assets/js/multilingual.js
@@ -49,12 +49,17 @@
             if (!copyFromLocale || currentLocale === copyFromLocale) return;
 
             // No usable translation provider configured: keep the plain one-click copy.
+            var defaultProvider = $(this).data('default-provider')
             var copyOpenHandler = $(this).data('copy-open-handler')
             if (!copyOpenHandler) {
                 self.copyLocale(copyFromLocale, '')
                 return
             }
 
+            if (defaultProvider) {
+                self.copyLocale(copyFromLocale, defaultProvider)
+                return
+            }
             self.$el.on('complete.oc.popup', function (e, $source, $popup) {
                 const $button = $popup.find(`[data-widget-id="${self.$el.attr('id')}"]`)
                 $button.on('click', function(event) {

--- a/assets/js/multilingual.js
+++ b/assets/js/multilingual.js
@@ -56,7 +56,7 @@
                 return
             }
 
-            if (defaultProvider) {
+            if (defaultProvider && event.shiftKey) {
                 self.copyLocale(copyFromLocale, defaultProvider)
                 return
             }

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -12,6 +12,7 @@ return [
     'settings' => [
         'title' => 'Translation Providers',
         'description' => 'Configure Google &amp; DeepL machine translation.',
+        'default_provider' => 'Default translation provider',
         'tab_google' => 'Google Translate',
         'tab_deepl' => 'DeepL',
 

--- a/models/Setting.php
+++ b/models/Setting.php
@@ -1,5 +1,6 @@
 <?php namespace Winter\Translate\Models;
 
+use Config;
 use Model;
 
 /**
@@ -78,5 +79,19 @@ class Setting extends Model
             $config->set('winter.translate::providers.deepl.key', $key);
             $config->set('winter.translate::providers.deepl.url', $settings->getDeeplUrl());
         }
+        $config->set('winter.translate::defaultProvider', $settings->defaultProvider);
+    }
+
+    public function filterFields($fields)
+    {
+        $providers = [];
+        if (!empty($fields->google_api_key->value)) {
+            $providers['google'] = 'Google';
+        }
+        if (!empty($fields->deepl_api_key->value)) {
+            $providers['deepl'] = 'Deepl';
+        }
+
+        $fields->defaultProvider->options = $providers;
     }
 }

--- a/models/setting/fields.yaml
+++ b/models/setting/fields.yaml
@@ -2,6 +2,14 @@
 #  Translation provider settings
 # ===================================
 
+fields:
+    defaultProvider:
+        label: winter.translate::lang.settings.default_provider
+        type: dropdown
+        emptyOption: -- select --
+        dependsOn: [google_api_key, deepl_api_key]
+        span: left
+
 tabs:
     fields:
 

--- a/traits/MLControl.php
+++ b/traits/MLControl.php
@@ -129,14 +129,21 @@ trait MLControl
         $this->vars['defaultLocale'] = $this->defaultLocale;
         $this->vars['locales'] = Locale::listAvailable();
         $this->vars['providers'] = $usableProviders;
+        $this->vars['defaultProvider'] = $this->getDefaultProvider($usableProviders);
+        $this->vars['field'] = $this->makeRenderFormField();
+    }
+
+    public function getDefaultProvider($usableProviders): ?string
+    {
         // Pre-select a provider only when exactly one is usable — a lone configured
         // provider is an unambiguous default that saves a click. With several, stay
         // on "None" so the user consciously picks a service rather than silently
         // defaulting to a paid one.
-        $this->vars['defaultProvider'] = count($usableProviders) === 1
-            ? (string) array_key_first($usableProviders)
-            : '';
-        $this->vars['field'] = $this->makeRenderFormField();
+        if (count($usableProviders) === 1) {
+            return (string) array_key_first($usableProviders);
+        } else {
+            return Config::get('winter.translate::defaultProvider');
+        }
     }
 
     /**

--- a/traits/mlcontrol/partials/_locale_selector.htm
+++ b/traits/mlcontrol/partials/_locale_selector.htm
@@ -27,6 +27,7 @@
                 type="button"
                 class="ml-locale-copy icon-copy"
                 data-copy-locale="<?= e($code) ?>"
+                <?php if ($defaultProvider): ?>data-default-provider="<?= e($defaultProvider) ?>"<?php endif ?>
                 <?php if ($hasProviders): ?>data-copy-open-handler="<?= e($this->getEventHandler('onShowTranslationMethodSelector')) ?>"<?php endif ?>
                 title="<?= e(trans('winter.translate::lang.locale.copy_from', ['locale' => $name])) ?>">
             </button>


### PR DESCRIPTION
Added a defaultProvider field to the Provider settings page.

Clicking the copy icon next to a locale in the locale selection popup with the SHIFT key also pressed will bypass the Provider selection popup if there is a single provider or the default provider has been set.

Clicking the copy icon next to a locale in the locale selection popup with the CTRL key also pressed will copy the selected locale's value directly without translation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to choose a default translation provider.
  * Locale copy controls can now automatically use the configured provider.
  * When only one provider is available, it can be selected automatically.

* **Bug Fixes**
  * Hold Shift to skip provider selection when a default provider is available.
  * Hold Ctrl/Cmd to copy the locale value without translation.
  * Existing provider selection behavior remains unchanged when no default provider is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->