### PR TITLE
Translate fields nested in a fieldset form widget

### DIFF
--- a/classes/EventRegistry.php
+++ b/classes/EventRegistry.php
@@ -128,7 +128,13 @@ class EventRegistry
         }
 
 
-        if (!$model->hasTranslatableAttributes() || $widget->isNested) {
+        // Nested forms are skipped: their fields belong to a separate data scope and do
+        // not map to the model's translatable attributes. Forms that share their parent's
+        // scope (ie. the fieldset widget) are the exception; the property check keeps this
+        // working on core releases that predate Form::$sharesParentScope.
+        $sharesParentScope = property_exists($widget, 'sharesParentScope') && $widget->sharesParentScope;
+
+        if (!$model->hasTranslatableAttributes() || ($widget->isNested && !$sharesParentScope)) {
             return;
         }
 

--- a/classes/EventRegistry.php
+++ b/classes/EventRegistry.php
@@ -129,12 +129,12 @@ class EventRegistry
 
 
         // Nested forms are skipped: their fields belong to a separate data scope and do
-        // not map to the model's translatable attributes. Forms that share their parent's
-        // scope (ie. the fieldset widget) are the exception; the property check keeps this
-        // working on core releases that predate Form::$sharesParentScope.
-        $sharesParentScope = property_exists($widget, 'sharesParentScope') && $widget->sharesParentScope;
+        // not map to the model's translatable attributes. The fieldset widget is the
+        // exception, grouping fields visually without a scope of its own; the property
+        // check keeps this working on core releases that predate Form::$sharesModelScope.
+        $sharesModelScope = property_exists($widget, 'sharesModelScope') && $widget->sharesModelScope;
 
-        if (!$model->hasTranslatableAttributes() || ($widget->isNested && !$sharesParentScope)) {
+        if (!$model->hasTranslatableAttributes() || ($widget->isNested && !$sharesModelScope)) {
             return;
         }
 

--- a/tests/unit/classes/EventRegistryTest.php
+++ b/tests/unit/classes/EventRegistryTest.php
@@ -1,6 +1,9 @@
 <?php namespace Winter\Translate\Tests\Unit;
 
 use Event;
+use Backend\Classes\Controller;
+use Backend\Classes\WidgetManager;
+use Backend\FormWidgets\FieldSet;
 use Backend\Widgets\Form;
 use Winter\Storm\Database\Model;
 
@@ -42,6 +45,87 @@ class EventRegistryTest extends \Winter\Translate\Tests\TranslatePluginTestCase
         $this->assertEquals('mltext', $form->tabs['fields']['tabTestField']['type']);
         $this->assertEquals('mltext', $form->secondaryTabs['fields']['secondaryTabTestField']['type']);
     }
+
+    public function testFieldsInANestedFormAreNotTranslated()
+    {
+        // A repeater's or nested form's fields belong to their own data scope and do
+        // not map to the model's translatable attributes.
+        $form = $this->makeScopeTestForm(Form::class, ['isNested' => true]);
+
+        $this->assertEquals('text', $form->fields['testField']['type']);
+    }
+
+    public function testFieldsInAScopeSharingNestedFormAreTranslated()
+    {
+        $form = $this->makeScopeTestForm(ScopeSharingFormStub::class, ['isNested' => true]);
+
+        $this->assertEquals('mltext', $form->fields['testField']['type']);
+    }
+
+    public function testFieldSetFieldsAreTranslated()
+    {
+        if (!property_exists(Form::class, 'sharesParentScope')) {
+            $this->markTestSkipped('Requires Form::$sharesParentScope, see wintercms/winter#1529.');
+        }
+
+        WidgetManager::instance()->registerFormWidget(FieldSet::class, 'fieldset');
+
+        $form = $this->makeScopeTestForm(Form::class, [
+            'fields' => [
+                'group' => [
+                    'type' => 'fieldset',
+                    'label' => 'Grouped Fields',
+                    'fields' => [
+                        'testField' => ['type' => 'text'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $fieldSet = $form->getFormWidget('group');
+        $this->assertInstanceOf(FieldSet::class, $fieldSet);
+
+        $inner = \Closure::bind(fn () => $this->formWidget, $fieldSet, FieldSet::class)();
+
+        $this->assertEquals('mltext', $inner->fields['testField']['type']);
+    }
+
+    protected function makeScopeTestForm(string $class, array $config = []): Form
+    {
+        $form = new $class(new Controller, array_merge([
+            'model' => new ScopeTestModel,
+            'arrayName' => 'array',
+            'fields' => [
+                'testField' => [
+                    'type' => 'text',
+                    'label' => 'Test 1',
+                ],
+            ],
+        ], $config));
+
+        $form->bindToController();
+
+        return $form;
+    }
+}
+
+/**
+ * A nested form sharing its parent form's data scope, as the fieldset form widget does.
+ * The property is declared here so that these tests also run against core releases that
+ * predate Form::$sharesParentScope.
+ */
+class ScopeSharingFormStub extends Form
+{
+    public $sharesParentScope = true;
+}
+
+class ScopeTestModel extends Model
+{
+    public $implement = [
+        'Winter.Translate.Behaviors.TranslatableModel',
+    ];
+
+    public $translatable = ['testField'];
 }
 
 class FormTestModel extends Model

--- a/tests/unit/classes/EventRegistryTest.php
+++ b/tests/unit/classes/EventRegistryTest.php
@@ -4,6 +4,7 @@ use Event;
 use Backend\Classes\Controller;
 use Backend\Classes\WidgetManager;
 use Backend\FormWidgets\FieldSet;
+use Backend\FormWidgets\Repeater;
 use Backend\Widgets\Form;
 use Winter\Storm\Database\Model;
 
@@ -55,17 +56,17 @@ class EventRegistryTest extends \Winter\Translate\Tests\TranslatePluginTestCase
         $this->assertEquals('text', $form->fields['testField']['type']);
     }
 
-    public function testFieldsInAScopeSharingNestedFormAreTranslated()
+    public function testFieldsInAModelScopedNestedFormAreTranslated()
     {
-        $form = $this->makeScopeTestForm(ScopeSharingFormStub::class, ['isNested' => true]);
+        $form = $this->makeScopeTestForm(ModelScopedFormStub::class, ['isNested' => true]);
 
         $this->assertEquals('mltext', $form->fields['testField']['type']);
     }
 
     public function testFieldSetFieldsAreTranslated()
     {
-        if (!property_exists(Form::class, 'sharesParentScope')) {
-            $this->markTestSkipped('Requires Form::$sharesParentScope, see wintercms/winter#1529.');
+        if (!property_exists(Form::class, 'sharesModelScope')) {
+            $this->markTestSkipped('Requires Form::$sharesModelScope, see wintercms/winter#1529.');
         }
 
         WidgetManager::instance()->registerFormWidget(FieldSet::class, 'fieldset');
@@ -90,6 +91,49 @@ class EventRegistryTest extends \Winter\Translate\Tests\TranslatePluginTestCase
         $this->assertEquals('mltext', $inner->fields['testField']['type']);
     }
 
+    public function testFieldSetFieldsInsideARepeaterAreNotTranslated()
+    {
+        if (!property_exists(Form::class, 'sharesModelScope')) {
+            $this->markTestSkipped('Requires Form::$sharesModelScope, see wintercms/winter#1529.');
+        }
+
+        WidgetManager::instance()->registerFormWidget(FieldSet::class, 'fieldset');
+        WidgetManager::instance()->registerFormWidget(Repeater::class, 'repeater');
+
+        $model = new ScopeTestModel;
+        $model->items = [['testField' => 'first']];
+
+        $form = $this->makeScopeTestForm(Form::class, [
+            'model' => $model,
+            'fields' => [
+                'items' => [
+                    'type' => 'repeater',
+                    'form' => [
+                        'fields' => [
+                            'group' => [
+                                'type' => 'fieldset',
+                                'fields' => [
+                                    // Deliberately collides with a translatable attribute.
+                                    'testField' => ['type' => 'text'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $repeater = $form->getFormWidget('items');
+        $itemForms = \Closure::bind(fn () => $this->formWidgets, $repeater, Repeater::class)();
+
+        $fieldSet = $itemForms[0]->getFormWidget('group');
+        $inner = \Closure::bind(fn () => $this->formWidget, $fieldSet, FieldSet::class)();
+
+        // The fieldset inherits the repeater item's scope, so its fields hold repeater
+        // data rather than the model's translatable attribute of the same name.
+        $this->assertEquals('text', $inner->fields['testField']['type']);
+    }
+
     protected function makeScopeTestForm(string $class, array $config = []): Form
     {
         $form = new $class(new Controller, array_merge([
@@ -110,13 +154,13 @@ class EventRegistryTest extends \Winter\Translate\Tests\TranslatePluginTestCase
 }
 
 /**
- * A nested form sharing its parent form's data scope, as the fieldset form widget does.
- * The property is declared here so that these tests also run against core releases that
- * predate Form::$sharesParentScope.
+ * A nested form resolving against the model's own attributes, as the fieldset form widget
+ * does. The property is declared here so that these tests also run against core releases
+ * that predate Form::$sharesModelScope.
  */
-class ScopeSharingFormStub extends Form
+class ModelScopedFormStub extends Form
 {
-    public $sharesParentScope = true;
+    public $sharesModelScope = true;
 }
 
 class ScopeTestModel extends Model
@@ -124,6 +168,8 @@ class ScopeTestModel extends Model
     public $implement = [
         'Winter.Translate.Behaviors.TranslatableModel',
     ];
+
+    protected $jsonable = ['items'];
 
     public $translatable = ['testField'];
 }


### PR DESCRIPTION
Fields nested inside a `fieldset` form widget never get their `ml*` widget, so translatable attributes grouped in a fieldset are not translatable in the backend.

`registerModelTranslation()` skips any nested form. That guard is right for `repeater` and `nestedform`: their fields belong to their own data scope and do not map to the model's translatable attributes. `fieldset` is different — it reuses the parent form's model *and* `arrayName`, and merges its `getSaveData()` straight back up, so its fields are model attributes exactly as if they had been declared on the parent form.

Core distinguishes the two cases with a new `Form::$sharesModelScope` flag (wintercms/winter#1528); this checks it, and the `property_exists()` guard keeps the plugin working unchanged on core releases that predate the property.

**Depends on wintercms/winter#1528.** Safe to merge independently: without core support `property_exists()` is `false` and behaviour is identical to today. If that PR settles on a different property name, this needs the same rename.

### Tests

Added to `tests/unit/classes/EventRegistryTest.php`:

| Test | Against Winter `develop` (what CI runs) | Against wintercms/winter#1529 |
| --- | --- | --- |
| fields in a nested form are not translated | passes | passes |
| fields in a model scoped nested form are translated | passes | passes |
| fieldset fields are translated (end-to-end, real `FieldSet` widget) | skipped | passes |
| fieldset fields inside a repeater are not translated | skipped | passes |

The second test uses a `Form` subclass that declares `sharesModelScope` itself, so the new branch stays covered on core releases that predate the property — it does not silently become a no-op on today's CI. The last two go through the real fieldset widget and skip until core provides the flag. Reverting the guard fails tests 2 and 3; hardcoding the core flag to `true` instead of deriving it fails test 4, where a repeater sub-field sharing a name with a translatable attribute would otherwise be turned into an `mltext`.

Full plugin suite green against a patched core: 56 tests, 168 assertions.

### Manual verification

Verified on a settings model with 22 translatable attributes, all inside `type: fieldset` groups: with the change all 22 render as `ml*` widgets inside the fieldset; with the original `$widget->isNested` guard restored, 0 — confirming the fieldset's inner form still reports `isNested === true`, so nothing else that relies on that flag is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected translation handling for fields in nested forms.
  - Fields in model-scoped nested forms and fieldsets are now translated correctly.
  - Prevented unintended translations for fields in regular nested forms and fieldsets inside repeaters.

- **Tests**
  - Added coverage for nested form, fieldset, repeater, and model-scoped translation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->