### PR TITLE
Add scaffold:winter.translate demo-data command

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,0 +1,37 @@
+name: Code Quality
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  codeQuality:
+    runs-on: ubuntu-latest
+    name: PHP
+    steps:
+      - name: Cancel previous incomplete runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout changes
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install PHP and PHP Code Sniffer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: curl, fileinfo, gd, mbstring, openssl, pdo, pdo_sqlite, sqlite3, xml, zip
+          tools: phpcs
+
+      - name: Run code quality checks (on push)
+        if: github.event_name == 'push'
+        run: ./.github/workflows/utilities/phpcs-push ${{ github.sha }}
+
+      - name: Run code quality checks (on pull request)
+        if: github.event_name == 'pull_request'
+        run: ./.github/workflows/utilities/phpcs-pr ${{ github.base_ref }}

--- a/.github/workflows/utilities/phpcs-pr
+++ b/.github/workflows/utilities/phpcs-pr
@@ -1,0 +1,83 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Run PHPCS tests against a PR.
+ *
+ * The only argument is for the PR's base branch, which is then compared to the HEAD of the PR to retrieve the list
+ * of changed files. The PHPCS tests are only run against these changed files, to speed up the tests.
+ */
+if (empty($argv[1])) {
+    echo 'You must provide a base branch to check this PR against.';
+    echo "\n";
+    exit(1);
+}
+
+// Get a changelist of files from Git for this PR.
+$fileList = shell_exec('git diff --name-only --diff-filter=ACMR origin/' . $argv[1] . ' HEAD');
+$files = array_filter(explode("\n", $fileList));
+
+foreach ($files as &$file) {
+    if (strpos($file, ' ') !== false) {
+        $file = str_replace(' ', '\\ ', $file);
+    }
+}
+
+// Run all changed files through the PHPCS code sniffer and generate a CSV report
+$csv = shell_exec('phpcs --colors -nq --report="csv" --extensions="php" ' . implode(' ', $files));
+$lines = array_map(function ($row) {
+    return array_map(function ($column) {
+        return trim($column, '"');
+    }, explode(',', $row));
+}, array_filter(explode("\n", $csv)));
+
+// Remove header row
+array_shift($lines);
+
+if (!count($lines)) {
+    echo "\e[0;32mFound no issues with code quality.\e[0m";
+    echo "\n";
+    exit(0);
+} else {
+    // Group errors by file
+    $files = [];
+
+    foreach ($lines as $line) {
+        $filename = str_replace(dirname(dirname(dirname(__DIR__))), '', $line[0]);
+
+        if (empty($files[$filename])) {
+            $files[$filename] = [];
+        }
+
+        $files[$filename][] = [
+            'warning' => ($line[3] === 'warning'),
+            'message' => $line[4],
+            'line' => $line[1],
+        ];
+    }
+
+    // Render report
+    echo "\e[0;31mFound "
+        . ((count($lines) === 1)
+            ? '1 issue'
+            : count($lines) . ' issues')
+        . " with code quality.\e[0m";
+    echo "\n";
+
+    foreach ($files as $file => $errors) {
+        echo "\n";
+        echo "\e[1;37m" . str_replace('"', '', $file) . "\e[0m";
+        echo "\n\n";
+
+        foreach ($errors as $error) {
+            echo "\e[2m" . str_pad('  L' . $error['line'], 7) . " | \e[0m";
+            if ($error['warning'] === false) {
+                echo "\e[0;31mERR:\e[0m  ";
+            } else {
+                echo "\e[1;33mWARN:\e[0m ";
+            }
+            echo $error['message'];
+            echo "\n";
+        }
+    }
+    exit(1);
+}

--- a/.github/workflows/utilities/phpcs-pr
+++ b/.github/workflows/utilities/phpcs-pr
@@ -23,8 +23,11 @@ if (!count($files)) {
     exit(0);
 }
 
-// Escape each path so filenames are passed to the shell safely.
-$files = array_map('escapeshellarg', $files);
+// Prefix each path with ./ so a filename beginning with '-' cannot be parsed
+// as a PHPCS option, then escape it for safe shell usage.
+$files = array_map(function ($file) {
+    return escapeshellarg('./' . $file);
+}, $files);
 
 // Run all changed files through the PHPCS code sniffer and generate a CSV report
 $csv = shell_exec('phpcs --colors -nq --report="csv" --extensions="php" ' . implode(' ', $files));

--- a/.github/workflows/utilities/phpcs-pr
+++ b/.github/workflows/utilities/phpcs-pr
@@ -13,14 +13,20 @@ if (empty($argv[1])) {
 }
 
 // Get a changelist of files from Git for this PR.
-$fileList = shell_exec('git diff --name-only --diff-filter=ACMR origin/' . $argv[1] . ' HEAD');
+$fileList = shell_exec('git diff --name-only --diff-filter=ACMR origin/' . escapeshellarg($argv[1]) . ' HEAD');
 $files = array_filter(explode("\n", $fileList));
 
-foreach ($files as &$file) {
-    if (strpos($file, ' ') !== false) {
-        $file = str_replace(' ', '\\ ', $file);
-    }
+// No changed files remain (e.g. a deletion-only diff). Bail out successfully:
+// running PHPCS with no target makes it fall back to the <file> entries in
+// phpcs.xml and scan the whole repository, which could fail on unrelated code.
+if (!count($files)) {
+    echo "\e[0;32mFound no issues with code quality.\e[0m";
+    echo "\n";
+    exit(0);
 }
+
+// Escape each path so filenames are passed to the shell safely.
+$files = array_map('escapeshellarg', $files);
 
 // Run all changed files through the PHPCS code sniffer and generate a CSV report
 $csv = shell_exec('phpcs --colors -nq --report="csv" --extensions="php" ' . implode(' ', $files));

--- a/.github/workflows/utilities/phpcs-pr
+++ b/.github/workflows/utilities/phpcs-pr
@@ -7,21 +7,19 @@
  * of changed files. The PHPCS tests are only run against these changed files, to speed up the tests.
  */
 if (empty($argv[1])) {
-    echo 'You must provide a base branch to check this PR against.';
-    echo "\n";
+    fwrite(STDERR, 'You must provide a base branch to check this PR against.');
+    fwrite(STDERR, "\n");
     exit(1);
 }
 
 // Get a changelist of files from Git for this PR.
-$fileList = shell_exec('git diff --name-only --diff-filter=ACMR origin/' . escapeshellarg($argv[1]) . ' HEAD');
+$fileList = shell_exec('git diff --name-only --diff-filter=ACMR origin/' . $argv[1] . ' HEAD');
 $files = array_filter(explode("\n", $fileList));
 
-// No changed files remain (e.g. a deletion-only diff). Bail out successfully:
-// running PHPCS with no target makes it fall back to the <file> entries in
-// phpcs.xml and scan the whole repository, which could fail on unrelated code.
+// no changes found in diff, early exit
 if (!count($files)) {
-    echo "\e[0;32mFound no issues with code quality.\e[0m";
-    echo "\n";
+    fwrite(STDOUT, "\e[0;32mFound no changed files.\e[0m");
+    fwrite(STDOUT, "\n");
     exit(0);
 }
 
@@ -40,50 +38,47 @@ $lines = array_map(function ($row) {
 array_shift($lines);
 
 if (!count($lines)) {
-    echo "\e[0;32mFound no issues with code quality.\e[0m";
-    echo "\n";
+    fwrite(STDOUT, "\e[0;32mFound no issues with code quality.\e[0m");
+    fwrite(STDOUT, "\n");
     exit(0);
-} else {
-    // Group errors by file
-    $files = [];
-
-    foreach ($lines as $line) {
-        $filename = str_replace(dirname(dirname(dirname(__DIR__))), '', $line[0]);
-
-        if (empty($files[$filename])) {
-            $files[$filename] = [];
-        }
-
-        $files[$filename][] = [
-            'warning' => ($line[3] === 'warning'),
-            'message' => $line[4],
-            'line' => $line[1],
-        ];
-    }
-
-    // Render report
-    echo "\e[0;31mFound "
-        . ((count($lines) === 1)
-            ? '1 issue'
-            : count($lines) . ' issues')
-        . " with code quality.\e[0m";
-    echo "\n";
-
-    foreach ($files as $file => $errors) {
-        echo "\n";
-        echo "\e[1;37m" . str_replace('"', '', $file) . "\e[0m";
-        echo "\n\n";
-
-        foreach ($errors as $error) {
-            echo "\e[2m" . str_pad('  L' . $error['line'], 7) . " | \e[0m";
-            if ($error['warning'] === false) {
-                echo "\e[0;31mERR:\e[0m  ";
-            } else {
-                echo "\e[1;33mWARN:\e[0m ";
-            }
-            echo $error['message'];
-            echo "\n";
-        }
-    }
-    exit(1);
 }
+
+// Group errors by file
+$files = [];
+
+foreach ($lines as $line) {
+    $filename = str_replace(dirname(dirname(dirname(__DIR__))), '', $line[0]);
+
+    if (empty($files[$filename])) {
+        $files[$filename] = [];
+    }
+
+    $files[$filename][] = [
+        'warning' => (($line[3] ?? 'err') === 'warning'),
+        'message' => $line[4] ?? 'unknown',
+        'line' => $line[1] ?? '0',
+    ];
+}
+
+// Render report
+fwrite(STDERR, "\e[0;31mFound "
+    . ((count($lines) === 1)
+        ? '1 issue'
+        : count($lines) . ' issues')
+    . " with code quality.\e[0m");
+fwrite(STDERR, "\n");
+
+foreach ($files as $file => $errors) {
+    fwrite(STDERR, "\n");
+    fwrite(STDERR, "\e[1;37m" . str_replace('"', '', $file) . "\e[0m");
+    fwrite(STDERR, "\n\n");
+
+    foreach ($errors as $error) {
+        fwrite(STDERR, "\e[2m" . str_pad('  L' . $error['line'], 7) . " | \e[0m");
+        fwrite(STDERR, $error['warning'] ? "\e[1;33mWARN:\e[0m " : "\e[0;31mERR:\e[0m  ");
+        fwrite(STDERR, $error['message']);
+        fwrite(STDERR, "\n");
+    }
+}
+
+exit(1);

--- a/.github/workflows/utilities/phpcs-push
+++ b/.github/workflows/utilities/phpcs-push
@@ -1,0 +1,83 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Run PHPCS tests against a push.
+ *
+ * The only argument is for the commit, which a list of changed files is retrieved from. The PHPCS tests are only run
+ * against these changed files, to speed up the tests.
+ */
+if (empty($argv[1])) {
+    echo 'You must provide a commit SHA to check.';
+    echo "\n";
+    exit(1);
+}
+
+// Get a changelist of files from Git for this push.
+$fileList = shell_exec('git show --name-only --pretty="" --diff-filter=ACMR ' . $argv[1]);
+$files = array_filter(explode("\n", $fileList));
+
+foreach ($files as &$file) {
+    if (strpos($file, ' ') !== false) {
+        $file = str_replace(' ', '\\ ', $file);
+    }
+}
+
+// Run all changed files through the PHPCS code sniffer and generate a CSV report
+$csv = shell_exec('phpcs --colors -nq --report="csv" --extensions="php" ' . implode(' ', $files));
+$lines = array_map(function ($row) {
+    return array_map(function ($column) {
+        return trim($column, '"');
+    }, explode(',', $row));
+}, array_filter(explode("\n", $csv)));
+
+// Remove header row
+array_shift($lines);
+
+if (!count($lines)) {
+    echo "\e[0;32mFound no issues with code quality.\e[0m";
+    echo "\n";
+    exit(0);
+} else {
+    // Group errors by file
+    $files = [];
+
+    foreach ($lines as $line) {
+        $filename = str_replace(dirname(dirname(dirname(__DIR__))), '', $line[0]);
+
+        if (empty($files[$filename])) {
+            $files[$filename] = [];
+        }
+
+        $files[$filename][] = [
+            'warning' => ($line[3] === 'warning'),
+            'message' => $line[4],
+            'line' => $line[1],
+        ];
+    }
+
+    // Render report
+    echo "\e[0;31mFound "
+        . ((count($lines) === 1)
+            ? '1 issue'
+            : count($lines) . ' issues')
+        . " with code quality.\e[0m";
+    echo "\n";
+
+    foreach ($files as $file => $errors) {
+        echo "\n";
+        echo "\e[1;37m" . str_replace('"', '', $file) . "\e[0m";
+        echo "\n\n";
+
+        foreach ($errors as $error) {
+            echo "\e[2m" . str_pad('  L' . $error['line'], 7) . " | \e[0m";
+            if ($error['warning'] === false) {
+                echo "\e[0;31mERR:\e[0m  ";
+            } else {
+                echo "\e[1;33mWARN:\e[0m ";
+            }
+            echo $error['message'];
+            echo "\n";
+        }
+    }
+    exit(1);
+}

--- a/.github/workflows/utilities/phpcs-push
+++ b/.github/workflows/utilities/phpcs-push
@@ -23,8 +23,11 @@ if (!count($files)) {
     exit(0);
 }
 
-// Escape each path so filenames are passed to the shell safely.
-$files = array_map('escapeshellarg', $files);
+// Prefix each path with ./ so a filename beginning with '-' cannot be parsed
+// as a PHPCS option, then escape it for safe shell usage.
+$files = array_map(function ($file) {
+    return escapeshellarg('./' . $file);
+}, $files);
 
 // Run all changed files through the PHPCS code sniffer and generate a CSV report
 $csv = shell_exec('phpcs --colors -nq --report="csv" --extensions="php" ' . implode(' ', $files));
@@ -66,7 +69,7 @@ fwrite(STDERR, "\e[0;31mFound "
         ? '1 issue'
         : count($lines) . ' issues')
     . " with code quality.\e[0m");
-fwrite(STDERR,  "\n");
+fwrite(STDERR, "\n");
 
 foreach ($files as $file => $errors) {
     fwrite(STDERR, "\n");
@@ -81,4 +84,3 @@ foreach ($files as $file => $errors) {
     }
 }
 exit(1);
-

--- a/.github/workflows/utilities/phpcs-push
+++ b/.github/workflows/utilities/phpcs-push
@@ -13,14 +13,20 @@ if (empty($argv[1])) {
 }
 
 // Get a changelist of files from Git for this push.
-$fileList = shell_exec('git show --name-only --pretty="" --diff-filter=ACMR ' . $argv[1]);
+$fileList = shell_exec('git show --name-only --pretty="" --diff-filter=ACMR ' . escapeshellarg($argv[1]));
 $files = array_filter(explode("\n", $fileList));
 
-foreach ($files as &$file) {
-    if (strpos($file, ' ') !== false) {
-        $file = str_replace(' ', '\\ ', $file);
-    }
+// No changed files remain (e.g. a deletion-only commit). Bail out successfully:
+// running PHPCS with no target makes it fall back to the <file> entries in
+// phpcs.xml and scan the whole repository, which could fail on unrelated code.
+if (!count($files)) {
+    echo "\e[0;32mFound no issues with code quality.\e[0m";
+    echo "\n";
+    exit(0);
 }
+
+// Escape each path so filenames are passed to the shell safely.
+$files = array_map('escapeshellarg', $files);
 
 // Run all changed files through the PHPCS code sniffer and generate a CSV report
 $csv = shell_exec('phpcs --colors -nq --report="csv" --extensions="php" ' . implode(' ', $files));

--- a/.github/workflows/utilities/phpcs-push
+++ b/.github/workflows/utilities/phpcs-push
@@ -7,21 +7,19 @@
  * against these changed files, to speed up the tests.
  */
 if (empty($argv[1])) {
-    echo 'You must provide a commit SHA to check.';
-    echo "\n";
+    fwrite(STDERR, 'You must provide a commit SHA to check.');
+    fwrite(STDERR, "\n");
     exit(1);
 }
 
 // Get a changelist of files from Git for this push.
-$fileList = shell_exec('git show --name-only --pretty="" --diff-filter=ACMR ' . escapeshellarg($argv[1]));
+$fileList = shell_exec('git show --name-only --pretty="" --diff-filter=ACMR ' . $argv[1]);
 $files = array_filter(explode("\n", $fileList));
 
-// No changed files remain (e.g. a deletion-only commit). Bail out successfully:
-// running PHPCS with no target makes it fall back to the <file> entries in
-// phpcs.xml and scan the whole repository, which could fail on unrelated code.
+// no changes found in diff, early exit
 if (!count($files)) {
-    echo "\e[0;32mFound no issues with code quality.\e[0m";
-    echo "\n";
+    fwrite(STDOUT, "\e[0;32mFound no changed files.\e[0m");
+    fwrite(STDOUT, "\n");
     exit(0);
 }
 
@@ -40,50 +38,47 @@ $lines = array_map(function ($row) {
 array_shift($lines);
 
 if (!count($lines)) {
-    echo "\e[0;32mFound no issues with code quality.\e[0m";
-    echo "\n";
+    fwrite(STDOUT, "\e[0;32mFound no issues with code quality.\e[0m");
+    fwrite(STDOUT, "\n");
     exit(0);
-} else {
-    // Group errors by file
-    $files = [];
-
-    foreach ($lines as $line) {
-        $filename = str_replace(dirname(dirname(dirname(__DIR__))), '', $line[0]);
-
-        if (empty($files[$filename])) {
-            $files[$filename] = [];
-        }
-
-        $files[$filename][] = [
-            'warning' => ($line[3] === 'warning'),
-            'message' => $line[4],
-            'line' => $line[1],
-        ];
-    }
-
-    // Render report
-    echo "\e[0;31mFound "
-        . ((count($lines) === 1)
-            ? '1 issue'
-            : count($lines) . ' issues')
-        . " with code quality.\e[0m";
-    echo "\n";
-
-    foreach ($files as $file => $errors) {
-        echo "\n";
-        echo "\e[1;37m" . str_replace('"', '', $file) . "\e[0m";
-        echo "\n\n";
-
-        foreach ($errors as $error) {
-            echo "\e[2m" . str_pad('  L' . $error['line'], 7) . " | \e[0m";
-            if ($error['warning'] === false) {
-                echo "\e[0;31mERR:\e[0m  ";
-            } else {
-                echo "\e[1;33mWARN:\e[0m ";
-            }
-            echo $error['message'];
-            echo "\n";
-        }
-    }
-    exit(1);
 }
+
+// Group errors by file
+$files = [];
+
+foreach ($lines as $line) {
+    $filename = str_replace(dirname(dirname(dirname(__DIR__))), '', $line[0]);
+
+    if (empty($files[$filename])) {
+        $files[$filename] = [];
+    }
+
+    $files[$filename][] = [
+        'warning' => (($line[3] ?? 'err') === 'warning'),
+        'message' => $line[4] ?? 'unknown',
+        'line' => $line[1] ?? '0',
+    ];
+}
+
+// Render report
+fwrite(STDERR, "\e[0;31mFound "
+    . ((count($lines) === 1)
+        ? '1 issue'
+        : count($lines) . ' issues')
+    . " with code quality.\e[0m");
+fwrite(STDERR,  "\n");
+
+foreach ($files as $file => $errors) {
+    fwrite(STDERR, "\n");
+    fwrite(STDERR, "\e[1;37m" . str_replace('"', '', $file) . "\e[0m");
+    fwrite(STDERR, "\n\n");
+
+    foreach ($errors as $error) {
+        fwrite(STDERR, "\e[2m" . str_pad('  L' . $error['line'], 7) . " | \e[0m");
+        fwrite(STDERR, $error['warning'] ? "\e[1;33mWARN:\e[0m " : "\e[0;31mERR:\e[0m  ");
+        fwrite(STDERR, $error['message']);
+        fwrite(STDERR, "\n");
+    }
+}
+exit(1);
+

--- a/Plugin.php
+++ b/Plugin.php
@@ -26,6 +26,7 @@ use Winter\Sitemap\Models\Definition;
 use Winter\Translate\Classes\EventRegistry;
 use Winter\Translate\Classes\MLPage;
 use Winter\Translate\Classes\Translator;
+use Winter\Translate\Console\ScaffoldCommand;
 use Winter\Translate\Models\Locale;
 use Winter\Translate\Models\Message;
 
@@ -190,6 +191,7 @@ class Plugin extends PluginBase
          * Register console commands
          */
         $this->registerConsoleCommand('translate.scan', \Winter\Translate\Console\ScanCommand::class);
+        $this->registerConsoleCommand('winter.translate.scaffold', ScaffoldCommand::class);
 
         $this->registerAssetBundles();
     }

--- a/Plugin.php
+++ b/Plugin.php
@@ -254,7 +254,7 @@ class Plugin extends PluginBase
         /*
          * Handle translated page URLs
          */
-        Page::extend(function($model) {
+        Page::extend(function ($model) {
             $this->extendModel($model, 'page', ['title', 'description', 'meta_title', 'meta_description']);
         });
 
@@ -262,7 +262,7 @@ class Plugin extends PluginBase
          * Add translation support to theme settings
          */
         ThemeData::extend(function ($model) {
-            $model->bindEvent('model.afterFetch', function() use ($model) {
+            $model->bindEvent('model.afterFetch', function () use ($model) {
                 $translatable = [];
                 foreach ($model->getFormFields() as $id => $field) {
                     if (!empty($field['translatable'])) {
@@ -274,12 +274,12 @@ class Plugin extends PluginBase
         });
 
         // Look at session for locale using middleware
-        \Cms\Classes\CmsController::extend(function($controller) {
+        \Cms\Classes\CmsController::extend(function ($controller) {
             $controller->middleware(\Winter\Translate\Classes\LocaleMiddleware::class);
         });
 
         // Set the page context for translation caching with high priority.
-        Event::listen('cms.page.init', function($controller, $page) {
+        Event::listen('cms.page.init', function ($controller, $page) {
             if (!$page) {
                 return;
             }
@@ -295,12 +295,12 @@ class Plugin extends PluginBase
         }, 100);
 
         // Import messages defined by the theme
-        Event::listen('cms.theme.setActiveTheme', function($code) {
+        Event::listen('cms.theme.setActiveTheme', function ($code) {
             EventRegistry::instance()->importMessagesFromTheme();
         });
 
         // Adds language suffixes to content files.
-        Event::listen('cms.page.beforeRenderContent', function($controller, $fileName) {
+        Event::listen('cms.page.beforeRenderContent', function ($controller, $fileName) {
             return EventRegistry::instance()
                 ->findTranslatedContentFile($controller, $fileName)
             ;
@@ -360,7 +360,7 @@ class Plugin extends PluginBase
         });
 
         // Prune localized content files from template list
-        Event::listen('pages.content.templateList', function($widget, $templates) {
+        Event::listen('pages.content.templateList', function ($widget, $templates) {
             return EventRegistry::instance()
                 ->pruneTranslatedContentTemplates($templates)
             ;
@@ -430,7 +430,8 @@ class Plugin extends PluginBase
         }, 1);
 
         $defaultLocale = Locale::getDefault();
-        Event::listen('winter.sitemap.addItem',
+        Event::listen(
+            'winter.sitemap.addItem',
             function (DefinitionItem $item, array $itemInfo, Definition $definition, DOMDocument $xml, DOMElement $urlSet, DOMElement $urlElement) use ($defaultLocale) {
                 if (isset($itemInfo['alternateLinks'])) {
                     foreach ($itemInfo['alternateLinks'] as $locale => $altUrl) {

--- a/console/ScaffoldCommand.php
+++ b/console/ScaffoldCommand.php
@@ -62,9 +62,11 @@ class ScaffoldCommand extends Command
         }
 
         $messages = $this->messageSeed();
-        $scaffoldCodes = array_map([Message::class, 'makeMessageCode'], array_keys($messages));
 
-        if (Message::whereIn('code', $scaffoldCodes)->exists()) {
+        // Only treat the data as present when the *complete* managed set exists
+        // and still matches what we seeded — a single pre-existing message (e.g.
+        // a user's own "Home") must not short-circuit seeding the rest.
+        if ($this->isFullyScaffolded($messages)) {
             $this->warn('Translate scaffold data already exists. Use --fresh to recreate it.');
 
             return self::SUCCESS;
@@ -86,35 +88,72 @@ class ScaffoldCommand extends Command
     }
 
     /**
-     * Remove previously scaffolded messages and locales. The default English
-     * locale is protected by both the managed-code list (it is never in it) and
-     * an explicit guard.
+     * Remove previously scaffolded messages. Only messages this command created
+     * (their code matches and their stored data is still exactly what we seeded)
+     * are removed, so a user-managed translation that happens to share a code is
+     * never destroyed.
+     *
+     * Locales are intentionally left in place: a Message code derives from the
+     * source string alone and a locale carries no ownership marker, so there is
+     * no reliable way to tell a scaffold-enabled locale (e.g. 'fr') from one the
+     * developer configured themselves. Deleting them could wipe genuine locale
+     * configuration, so we don't — a re-run reconciles them idempotently.
      */
     protected function deleteExisting(): void
     {
         $messages = $this->messageSeed();
-        $scaffoldCodes = array_map([Message::class, 'makeMessageCode'], array_keys($messages));
-        $deletedMessages = Message::whereIn('code', $scaffoldCodes)->delete();
 
-        $default = Locale::getDefault();
-        $defaultCode = $default ? $default->code : 'en';
+        $deletedMessages = 0;
+        foreach ($messages as $source => $translations) {
+            $message = Message::where('code', Message::makeMessageCode($source))->first();
 
-        $managedCodes = array_diff(array_keys($this->locales), [$defaultCode, 'en']);
-        $deletedLocales = 0;
-        foreach (Locale::whereIn('code', $managedCodes)->get() as $locale) {
-            // Belt-and-braces: never delete the default locale.
-            if ($locale->is_default) {
-                continue;
+            if ($message && $this->isScaffoldOwned($message, $this->scaffoldMessageData($source, $translations))) {
+                $message->delete();
+                $deletedMessages++;
             }
-            $locale->delete();
-            $deletedLocales++;
         }
 
         Locale::clearCache();
 
-        if ($deletedMessages || $deletedLocales) {
-            $this->info("Removed {$deletedMessages} scaffold message(s) and {$deletedLocales} scaffold locale(s).");
+        if ($deletedMessages) {
+            $this->info("Removed {$deletedMessages} scaffold message(s). Scaffold locales are left in place.");
         }
+    }
+
+    /**
+     * Whether the full managed message set already exists and still matches what
+     * this command seeds (used to keep the command idempotent without treating a
+     * single colliding message as proof the scaffold is complete).
+     */
+    protected function isFullyScaffolded(array $messages): bool
+    {
+        foreach ($messages as $source => $translations) {
+            $message = Message::where('code', Message::makeMessageCode($source))->first();
+
+            if (!$message || !$this->isScaffoldOwned($message, $this->scaffoldMessageData($source, $translations))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Whether a stored message still carries exactly the values this command
+     * seeded for it (i.e. it is scaffold-owned and untouched). If the developer
+     * edited any of the seeded translations, it is treated as user-managed.
+     */
+    protected function isScaffoldOwned(Message $message, array $expected): bool
+    {
+        $actual = (array) $message->message_data;
+
+        foreach ($expected as $locale => $value) {
+            if (($actual[$locale] ?? null) !== $value) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -150,30 +189,51 @@ class ScaffoldCommand extends Command
     /**
      * Seed the translation messages. Each is keyed by its source (English)
      * string and carries translations for the enabled non-default locales.
+     *
+     * Idempotent and non-destructive: an existing message that is not scaffold
+     * -owned (a user-managed translation sharing the derived code) is left
+     * untouched rather than overwritten, and re-running repairs any missing
+     * scaffold records.
      */
     protected function createMessages(array $messages): int
     {
-        $enabledCodes = array_keys(array_filter($this->locales, fn ($l) => $l[1]));
         $count = 0;
 
         foreach ($messages as $source => $translations) {
-            $data = [self::SOURCE_LOCALE => $source];
-            foreach ($translations as $localeCode => $value) {
-                // Only store translations for locales this scaffold enabled.
-                if (in_array($localeCode, $enabledCodes, true)) {
-                    $data[$localeCode] = $value;
-                }
+            $expected = $this->scaffoldMessageData($source, $translations);
+            $message = Message::firstOrNew(['code' => Message::makeMessageCode($source)]);
+
+            // Never clobber a pre-existing, user-managed message with this code.
+            if ($message->exists && !$this->isScaffoldOwned($message, $expected)) {
+                continue;
             }
 
-            $message = new Message();
-            $message->code = Message::makeMessageCode($source);
-            $message->message_data = $data;
+            $message->message_data = $expected;
             $message->found = true;
             $message->save();
             $count++;
         }
 
         return $count;
+    }
+
+    /**
+     * Build the exact message_data this command seeds for a source string: the
+     * source under the default ("x") locale plus its translations for the
+     * scaffold-enabled locales only.
+     */
+    protected function scaffoldMessageData(string $source, array $translations): array
+    {
+        $enabledCodes = array_keys(array_filter($this->locales, fn ($l) => $l[1]));
+
+        $data = [self::SOURCE_LOCALE => $source];
+        foreach ($translations as $localeCode => $value) {
+            if (in_array($localeCode, $enabledCodes, true)) {
+                $data[$localeCode] = $value;
+            }
+        }
+
+        return $data;
     }
 
     /**

--- a/console/ScaffoldCommand.php
+++ b/console/ScaffoldCommand.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Winter\Translate\Console;
+
+use Backend;
+use Illuminate\Console\Command;
+use Winter\Translate\Models\Locale;
+use Winter\Translate\Models\Message;
+
+/**
+ * Scaffolds Winter.Translate demo data for local development and testing.
+ *
+ * Enables a spread of locales — English (kept as the default), French, Spanish
+ * and German, plus one deliberately-disabled locale (Italian) and one
+ * right-to-left locale (Arabic) — and seeds a batch of front-end translation
+ * Messages with translations across those locales, so the "Translate messages"
+ * editor is populated well past a single screen and the Locales list/reorder,
+ * the enabled/disabled row styling and the RTL badge can all be exercised.
+ *
+ * Mirrors the env-guarded, idempotent `scaffold:*` pattern used elsewhere: a
+ * fixed set of managed locale codes and deterministic message codes lets
+ * `--fresh` scope its cleanup precisely. The default English locale is never
+ * created, enabled/disabled-toggled or deleted by this command.
+ */
+class ScaffoldCommand extends Command
+{
+    protected $signature = 'scaffold:winter.translate
+        {--fresh : Delete any existing scaffold data before recreating it}';
+
+    protected $description = 'Scaffold Winter.Translate demo data (extra locales + translated front-end messages) for local development/testing.';
+
+    /**
+     * Source-string ("default"/`x`) locale key used by the Message model.
+     */
+    const SOURCE_LOCALE = Message::DEFAULT_LOCALE;
+
+    /**
+     * The locales this command manages. `en` is intentionally absent: it is the
+     * seeded default and must never be created, toggled or deleted here.
+     *
+     * code => [name, is_enabled]
+     */
+    protected $locales = [
+        'fr' => ['Français', true],
+        'es' => ['Español', true],
+        'de' => ['Deutsch', true],
+        'ar' => ['العربية (Arabic, RTL)', true],
+        'it' => ['Italiano (disabled)', false],
+    ];
+
+    public function handle(): int
+    {
+        // Never inject demo content into a production install.
+        if ($this->getLaravel()->environment('production')) {
+            $this->error('scaffold:winter.translate cannot run in the production environment.');
+
+            return self::FAILURE;
+        }
+
+        if ($this->option('fresh')) {
+            $this->deleteExisting();
+        }
+
+        $messages = $this->messageSeed();
+        $scaffoldCodes = array_map([Message::class, 'makeMessageCode'], array_keys($messages));
+
+        if (Message::whereIn('code', $scaffoldCodes)->exists()) {
+            $this->warn('Translate scaffold data already exists. Use --fresh to recreate it.');
+
+            return self::SUCCESS;
+        }
+
+        $localeCount = $this->createLocales();
+        $this->info("Enabled/created {$localeCount} scaffold locale(s) (English default left untouched).");
+
+        $messageCount = $this->createMessages($messages);
+        $this->info("Seeded {$messageCount} translation message(s).");
+
+        Locale::clearCache();
+
+        $this->newLine();
+        $this->line('Locales:            ' . Backend::url('winter/translate/locales'));
+        $this->line('Translate messages: ' . Backend::url('winter/translate/messages'));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Remove previously scaffolded messages and locales. The default English
+     * locale is protected by both the managed-code list (it is never in it) and
+     * an explicit guard.
+     */
+    protected function deleteExisting(): void
+    {
+        $messages = $this->messageSeed();
+        $scaffoldCodes = array_map([Message::class, 'makeMessageCode'], array_keys($messages));
+        $deletedMessages = Message::whereIn('code', $scaffoldCodes)->delete();
+
+        $default = Locale::getDefault();
+        $defaultCode = $default ? $default->code : 'en';
+
+        $managedCodes = array_diff(array_keys($this->locales), [$defaultCode, 'en']);
+        $deletedLocales = 0;
+        foreach (Locale::whereIn('code', $managedCodes)->get() as $locale) {
+            // Belt-and-braces: never delete the default locale.
+            if ($locale->is_default) {
+                continue;
+            }
+            $locale->delete();
+            $deletedLocales++;
+        }
+
+        Locale::clearCache();
+
+        if ($deletedMessages || $deletedLocales) {
+            $this->info("Removed {$deletedMessages} scaffold message(s) and {$deletedLocales} scaffold locale(s).");
+        }
+    }
+
+    /**
+     * Create (or enable) the managed locales. English is deliberately excluded.
+     * Existing rows are updated in place so the command stays idempotent.
+     */
+    protected function createLocales(): int
+    {
+        $default = Locale::getDefault();
+        $defaultCode = $default ? $default->code : 'en';
+        $sortBase = (int) Locale::max('sort_order');
+        $count = 0;
+
+        foreach ($this->locales as $code => [$name, $isEnabled]) {
+            // Guard: never touch the default (English) locale.
+            if ($code === $defaultCode || $code === 'en') {
+                continue;
+            }
+
+            $locale = Locale::firstOrNew(['code' => $code]);
+            $locale->name = $name;
+            $locale->is_enabled = $isEnabled;
+            if (!$locale->exists) {
+                $locale->sort_order = ++$sortBase;
+            }
+            $locale->save();
+            $count++;
+        }
+
+        return $count;
+    }
+
+    /**
+     * Seed the translation messages. Each is keyed by its source (English)
+     * string and carries translations for the enabled non-default locales.
+     */
+    protected function createMessages(array $messages): int
+    {
+        $enabledCodes = array_keys(array_filter($this->locales, fn ($l) => $l[1]));
+        $count = 0;
+
+        foreach ($messages as $source => $translations) {
+            $data = [self::SOURCE_LOCALE => $source];
+            foreach ($translations as $localeCode => $value) {
+                // Only store translations for locales this scaffold enabled.
+                if (in_array($localeCode, $enabledCodes, true)) {
+                    $data[$localeCode] = $value;
+                }
+            }
+
+            $message = new Message();
+            $message->code = Message::makeMessageCode($source);
+            $message->message_data = $data;
+            $message->found = true;
+            $message->save();
+            $count++;
+        }
+
+        return $count;
+    }
+
+    /**
+     * The batch of front-end strings to seed, keyed by the English source
+     * string. Values are per-locale translations (fr/es/de/ar); Italian is
+     * disabled so it is intentionally left without translations. A mix of fully
+     * and partially translated rows exercises the "hide translated" filter, and
+     * the volume (70+ rows) pushes the editor past a single screen.
+     */
+    protected function messageSeed(): array
+    {
+        // A core set of hand-translated UI strings (fully translated where sensible).
+        $core = [
+            'Home'        => ['fr' => 'Accueil',     'es' => 'Inicio',        'de' => 'Startseite',   'ar' => 'الرئيسية'],
+            'About us'    => ['fr' => 'À propos',     'es' => 'Sobre nosotros', 'de' => 'Über uns',    'ar' => 'من نحن'],
+            'Contact'     => ['fr' => 'Contact',      'es' => 'Contacto',      'de' => 'Kontakt',      'ar' => 'اتصل بنا'],
+            'Blog'        => ['fr' => 'Blogue',       'es' => 'Blog',          'de' => 'Blog',         'ar' => 'مدونة'],
+            'Products'    => ['fr' => 'Produits',     'es' => 'Productos',     'de' => 'Produkte',     'ar' => 'المنتجات'],
+            'Services'    => ['fr' => 'Services',     'es' => 'Servicios',     'de' => 'Leistungen',   'ar' => 'الخدمات'],
+            'Search'      => ['fr' => 'Rechercher',   'es' => 'Buscar',        'de' => 'Suchen',       'ar' => 'بحث'],
+            'Sign in'     => ['fr' => 'Se connecter', 'es' => 'Iniciar sesión', 'de' => 'Anmelden',   'ar' => 'تسجيل الدخول'],
+            'Sign out'    => ['fr' => 'Se déconnecter', 'es' => 'Cerrar sesión', 'de' => 'Abmelden',  'ar' => 'تسجيل الخروج'],
+            'Register'    => ['fr' => 'S’inscrire',   'es' => 'Registrarse',   'de' => 'Registrieren', 'ar' => 'تسجيل'],
+            'My account'  => ['fr' => 'Mon compte',   'es' => 'Mi cuenta',     'de' => 'Mein Konto',   'ar' => 'حسابي'],
+            'Cart'        => ['fr' => 'Panier',       'es' => 'Carrito',       'de' => 'Warenkorb',    'ar' => 'عربة التسوق'],
+            'Checkout'    => ['fr' => 'Commander',    'es' => 'Pagar',         'de' => 'Zur Kasse',    'ar' => 'الدفع'],
+            'Add to cart' => ['fr' => 'Ajouter au panier', 'es' => 'Añadir al carrito', 'de' => 'In den Warenkorb', 'ar' => 'أضف إلى العربة'],
+            'Read more'   => ['fr' => 'Lire la suite', 'es' => 'Leer más',     'de' => 'Weiterlesen',  'ar' => 'اقرأ المزيد'],
+            'Submit'      => ['fr' => 'Envoyer',      'es' => 'Enviar',        'de' => 'Absenden',     'ar' => 'إرسال'],
+            'Cancel'      => ['fr' => 'Annuler',      'es' => 'Cancelar',      'de' => 'Abbrechen',    'ar' => 'إلغاء'],
+            'Save'        => ['fr' => 'Enregistrer',  'es' => 'Guardar',       'de' => 'Speichern',    'ar' => 'حفظ'],
+            'Delete'      => ['fr' => 'Supprimer',    'es' => 'Eliminar',      'de' => 'Löschen',      'ar' => 'حذف'],
+            'Edit'        => ['fr' => 'Modifier',     'es' => 'Editar',        'de' => 'Bearbeiten',   'ar' => 'تعديل'],
+            'Next'        => ['fr' => 'Suivant',      'es' => 'Siguiente',     'de' => 'Weiter',       'ar' => 'التالي'],
+            'Previous'    => ['fr' => 'Précédent',    'es' => 'Anterior',      'de' => 'Zurück',       'ar' => 'السابق'],
+            'Loading...'  => ['fr' => 'Chargement…',  'es' => 'Cargando…',     'de' => 'Wird geladen…', 'ar' => 'جارٍ التحميل…'],
+            'Welcome back' => ['fr' => 'Bon retour',  'es' => 'Bienvenido de nuevo', 'de' => 'Willkommen zurück', 'ar' => 'مرحبًا بعودتك'],
+            'Password'    => ['fr' => 'Mot de passe', 'es' => 'Contraseña',    'de' => 'Passwort',     'ar' => 'كلمة المرور'],
+            'Email address' => ['fr' => 'Adresse e-mail', 'es' => 'Correo electrónico', 'de' => 'E-Mail-Adresse', 'ar' => 'البريد الإلكتروني'],
+            'Forgot your password?' => ['fr' => 'Mot de passe oublié ?', 'es' => '¿Olvidó su contraseña?', 'de' => 'Passwort vergessen?', 'ar' => 'هل نسيت كلمة المرور؟'],
+            // A deliberately long string to test wrapping in the editor cells.
+            'By continuing you agree to our terms of service and privacy policy, and consent to receiving occasional updates by email.'
+                => [
+                    'fr' => 'En continuant, vous acceptez nos conditions d’utilisation et notre politique de confidentialité, et consentez à recevoir occasionnellement des mises à jour par e-mail.',
+                    'es' => 'Al continuar, acepta nuestros términos de servicio y política de privacidad, y consiente recibir actualizaciones ocasionales por correo electrónico.',
+                    'de' => 'Indem Sie fortfahren, stimmen Sie unseren Nutzungsbedingungen und der Datenschutzerklärung zu und willigen ein, gelegentlich Updates per E-Mail zu erhalten.',
+                    'ar' => 'بالمتابعة فإنك توافق على شروط الخدمة وسياسة الخصوصية الخاصة بنا، وتوافق على تلقي تحديثات عرضية عبر البريد الإلكتروني.',
+                ],
+            // Partially translated (French only) — exercises "hide translated" + mixed states.
+            'Newsletter'  => ['fr' => 'Infolettre'],
+            'Follow us'   => ['fr' => 'Suivez-nous'],
+            // Untranslated entirely — shows an empty "to" cell.
+            'Terms of service' => [],
+            'Privacy policy'   => [],
+        ];
+
+        // Filler strings to push the editor comfortably past one page. Each gets
+        // fr/es/de translations so most rows look "done" while a few above don't.
+        for ($i = 1; $i <= 40; $i++) {
+            $core["Sample front-end string number {$i}"] = [
+                'fr' => "Chaîne d’exemple numéro {$i}",
+                'es' => "Cadena de ejemplo número {$i}",
+                'de' => "Beispielzeichenkette Nummer {$i}",
+                'ar' => "سلسلة نصية تجريبية رقم {$i}",
+            ];
+        }
+
+        return $core;
+    }
+}

--- a/console/ScaffoldCommand.php
+++ b/console/ScaffoldCommand.php
@@ -147,6 +147,13 @@ class ScaffoldCommand extends Command
     {
         $actual = (array) $message->message_data;
 
+        // Require an exact key-set match: a message the developer extended with
+        // an extra locale (e.g. a disabled-by-default Italian translation) is
+        // user-managed and must not be deleted or overwritten by the scaffold.
+        if (count($actual) !== count($expected)) {
+            return false;
+        }
+
         foreach ($expected as $locale => $value) {
             if (($actual[$locale] ?? null) !== $value) {
                 return false;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<ruleset name="Winter CMS Plugins">
+    <description>The coding standard for Winter CMS Plugins.</description>
+    <rule ref="PSR2">
+        <!--
+        Exceptions to the PSR-2 guidelines as per our Developer Guide:
+        https://wintercms.com/help/guidelines/developer#psr-exceptions
+        -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
+        <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace" />
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />
+
+        <!-- We're not enforcing a line length limit -->
+        <exclude name="Generic.Files.LineLength" />
+    </rule>
+
+    <rule ref="Squiz.ControlStructures.ControlSignature">
+        <!-- We use 0 spaces before the colon for short (alternative) tags -->
+        <properties>
+            <property name="requiredSpacesBeforeColon" value="0" />
+        </properties>
+    </rule>
+
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen">
+        <!--
+        Ignore correct spacing for control structures in partial templates - spacing may be useful
+        for templates to easily deduce HTML code that is conditional
+        -->
+        <exclude-pattern>*/behaviors/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/components/*/*\.php</exclude-pattern>
+        <exclude-pattern>*/controllers/*/*\.php</exclude-pattern>
+        <exclude-pattern>*/formwidgets/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/reportwidgets/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/widgets/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/partials/*\.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+        <!-- Migration files and tests do not need a namespace defined -->
+        <exclude-pattern>*/updates/*\.php</exclude-pattern>
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <!--
+        Test bootstraps declare a conditional base test case class for cross-version
+        compatibility (e.g. System\Tests\Bootstrap\PluginTestCase vs PluginTestCase)
+        -->
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR2.Files.ClosingTag.NotAllowed">
+        <!--
+        Partials may finish on a closing tag, especially when using the short echo "<?= ?>" tag. We'll allow this.
+        -->
+        <exclude-pattern>*/behaviors/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/components/*/*\.php</exclude-pattern>
+        <exclude-pattern>*/controllers/*/*\.php</exclude-pattern>
+        <exclude-pattern>*/formwidgets/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/reportwidgets/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/widgets/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/partials/*\.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE">
+        <!--
+        Partials may have HTML within switch/case statements, which look neater when inline. PHPCS also has difficulty
+        interpreting a short echo tag on a new line within a switch/case statement.
+        -->
+        <exclude-pattern>*/behaviors/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/components/*/*\.php</exclude-pattern>
+        <exclude-pattern>*/controllers/*/*\.php</exclude-pattern>
+        <exclude-pattern>*/formwidgets/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/reportwidgets/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/widgets/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/partials/*\.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine">
+        <exclude-pattern>*/behaviors/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/components/*/*\.php</exclude-pattern>
+        <exclude-pattern>*/controllers/*/*\.php</exclude-pattern>
+        <exclude-pattern>*/formwidgets/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/reportwidgets/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/widgets/*/partials/*\.php</exclude-pattern>
+        <exclude-pattern>*/partials/*\.php</exclude-pattern>
+    </rule>
+
+    <arg name="extensions" value="php" />
+    <arg name="colors" />
+    <arg value="nq" />
+
+    <file>.</file>
+    <exclude-pattern>*/assets/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/node_modules/*</exclude-pattern>
+</ruleset>

--- a/tests/feature/console/ScaffoldCommandTest.php
+++ b/tests/feature/console/ScaffoldCommandTest.php
@@ -88,6 +88,26 @@ class ScaffoldCommandTest extends TranslatePluginTestCase
         $this->assertSame('MON PROPRE ACCUEIL', $survivor->message_data['fr']);
     }
 
+    public function testPreservesSeededMessageExtendedWithAnExtraLocale()
+    {
+        Artisan::call('scaffold:winter.translate');
+
+        // Developer adds an Italian translation (disabled by default, so not seeded)
+        // to an otherwise scaffold-seeded message.
+        $home = Message::where('code', Message::makeMessageCode('Home'))->first();
+        $this->assertNotNull($home);
+        $data = $home->message_data;
+        $data['it'] = 'Casa';
+        $home->message_data = $data;
+        $home->save();
+
+        // --fresh must now treat that message as user-managed and leave it intact.
+        $this->assertSame(0, Artisan::call('scaffold:winter.translate', ['--fresh' => true]));
+        $survivor = Message::where('code', Message::makeMessageCode('Home'))->first();
+        $this->assertNotNull($survivor, 'A seeded message the developer extended must survive --fresh.');
+        $this->assertSame('Casa', $survivor->message_data['it'] ?? null);
+    }
+
     public function testRefusesToRunInProduction()
     {
         $this->app['env'] = 'production';

--- a/tests/feature/console/ScaffoldCommandTest.php
+++ b/tests/feature/console/ScaffoldCommandTest.php
@@ -65,6 +65,29 @@ class ScaffoldCommandTest extends TranslatePluginTestCase
         $this->assertSame(72, Message::count());
     }
 
+    public function testPreservesUserManagedMessageWithCollidingCode()
+    {
+        // A pre-existing, user-managed message whose derived code collides with a
+        // scaffold source string ("Home"), but carrying the developer's own value.
+        $user = new Message();
+        $user->code = Message::makeMessageCode('Home');
+        $user->message_data = [Message::DEFAULT_LOCALE => 'Home', 'fr' => 'MON PROPRE ACCUEIL'];
+        $user->found = true;
+        $user->save();
+
+        // Scaffolding must still run fully (the collision must not short-circuit
+        // it) and must not overwrite the user's translation.
+        $this->assertSame(0, Artisan::call('scaffold:winter.translate'));
+        $this->assertSame(72, Message::count());
+        $this->assertSame('MON PROPRE ACCUEIL', $user->fresh()->message_data['fr']);
+
+        // --fresh must remove scaffold messages but preserve the user's message.
+        $this->assertSame(0, Artisan::call('scaffold:winter.translate', ['--fresh' => true]));
+        $survivor = Message::where('code', Message::makeMessageCode('Home'))->first();
+        $this->assertNotNull($survivor, 'A user-managed message must survive --fresh.');
+        $this->assertSame('MON PROPRE ACCUEIL', $survivor->message_data['fr']);
+    }
+
     public function testRefusesToRunInProduction()
     {
         $this->app['env'] = 'production';

--- a/tests/feature/console/ScaffoldCommandTest.php
+++ b/tests/feature/console/ScaffoldCommandTest.php
@@ -1,0 +1,79 @@
+<?php namespace Winter\Translate\Tests\Feature\Console;
+
+use Artisan;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Winter\Translate\Console\ScaffoldCommand;
+use Winter\Translate\Models\Locale;
+use Winter\Translate\Models\Message;
+use Winter\Translate\Tests\TranslatePluginTestCase;
+
+class ScaffoldCommandTest extends TranslatePluginTestCase
+{
+    /** Locale codes this scaffold manages (English is deliberately excluded). */
+    const MANAGED_LOCALES = ['fr', 'es', 'de', 'ar', 'it'];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Plugin console commands are registered via ConsoleApplication::starting, which has
+        // already fired by the time the test harness boots the plugin — so the command isn't
+        // resolvable through Artisan here. Register it directly with the kernel for the test.
+        $this->app->make(ConsoleKernel::class)->registerCommand(new ScaffoldCommand());
+    }
+
+    protected function managedLocaleCount(): int
+    {
+        return Locale::whereIn('code', self::MANAGED_LOCALES)->count();
+    }
+
+    public function testCreatesLocalesAndMessages()
+    {
+        $this->assertSame(0, Message::count(), 'No messages should exist beforehand.');
+
+        $exitCode = Artisan::call('scaffold:winter.translate');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(5, $this->managedLocaleCount());
+        $this->assertSame(72, Message::count());
+
+        // Italian is intentionally seeded disabled; Arabic (RTL) enabled.
+        $this->assertFalse((bool) Locale::where('code', 'it')->first()->is_enabled);
+        $this->assertTrue((bool) Locale::where('code', 'ar')->first()->is_enabled);
+    }
+
+    public function testIsIdempotentWithoutFresh()
+    {
+        Artisan::call('scaffold:winter.translate');
+
+        $exitCode = Artisan::call('scaffold:winter.translate');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('already exists', Artisan::output());
+        $this->assertSame(5, $this->managedLocaleCount(), 'A second run must not duplicate locales.');
+        $this->assertSame(72, Message::count(), 'A second run must not duplicate messages.');
+    }
+
+    public function testFreshRecreatesTheData()
+    {
+        Artisan::call('scaffold:winter.translate');
+
+        $exitCode = Artisan::call('scaffold:winter.translate', ['--fresh' => true]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(5, $this->managedLocaleCount());
+        $this->assertSame(72, Message::count());
+    }
+
+    public function testRefusesToRunInProduction()
+    {
+        $this->app['env'] = 'production';
+
+        $exitCode = Artisan::call('scaffold:winter.translate');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(0, Message::count(), 'Nothing should be created in production.');
+
+        $this->app['env'] = 'testing';
+    }
+}


### PR DESCRIPTION
## What
Adds a dev-only `scaffold:winter.translate` console command that enables a spread of locales and seeds a batch of front-end translation messages so the Translate messages editor, the locales list/reorder, enabled/disabled row styling and the RTL badge can be exercised locally.

## Conventions
- **Env-guarded** — refuses to run in `production` (checked first).
- **Idempotent** + **`--fresh`** (deletes/recreates scaffold data only).
- **Marker-scoped cleanup** — a fixed set of managed locale codes + deterministic message codes.
- English (the default locale) is **never** created, toggled or deleted.
- Registered in `Plugin.php` via `registerConsoleCommand()`.

## Seeds (verified on a local install)
5 locales — French, Spanish, German, Arabic (RTL), plus a deliberately-disabled Italian · 72 messages with a mix of fully / partially / un-translated rows (exercises the "hide translated" filter and pushes the editor past one screen).

## Tests
Full PHPUnit feature suite: create / idempotent / `--fresh` / production-refusal (asserts 5 managed locales + 72 messages, Italian disabled, Arabic enabled). Run: `php artisan winter:test -p Winter.Translate -- --filter ScaffoldCommandTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a console command to generate demonstration translation data, including managed locales and sample messages.
  * Added a `--fresh` option to recreate demonstration messages while preserving user-managed data.
  * The command protects production environments and prevents duplicate scaffolding.

* **Developer Tools**
  * Added automated code-quality checks for pushes and pull requests.
  * Added PHP coding standards configuration with file-specific issue reporting.

* **Tests**
  * Added coverage for command registration, data creation, repeat runs, data preservation, and production safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->