### PR TITLE
Keep the sitemap <loc> a localized URL

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -441,8 +441,15 @@ class Plugin extends PluginBase
                         $linkElement->setAttribute('href', $altUrl);
                         $urlElement->appendChild($linkElement);
                     }
+                    // A listener on pages.menuitem.resolveItem may narrow
+                    // alternateLinks. Without the default locale among them the
+                    // <loc> would keep the untranslated URL, which redirects.
+                    $primaryLocale = isset($itemInfo['alternateLinks'][$defaultLocale->code])
+                        ? $defaultLocale->code
+                        : array_key_first($itemInfo['alternateLinks']);
+
                     foreach ($itemInfo['alternateLinks'] as $locale => $altUrl) {
-                        if ($locale === $defaultLocale->code) {
+                        if ($locale === $primaryLocale) {
                             $loc = $urlElement->getElementsByTagName('loc')->item(0);
                             $loc->nodeValue = $altUrl;
                             continue;


### PR DESCRIPTION
### Problem

The `winter.sitemap.addItem` listener rewrites `<loc>` to the alternate for the default locale and clones a `<url>` for each of the others:

```php
if ($locale === $defaultLocale->code) {
    $loc->nodeValue = $altUrl;
    continue;
}
$newElement = $urlElement->cloneNode(true);
```

When the default locale is **not** among `alternateLinks`, the rewrite never happens and the element keeps the untranslated URL it was built with. That URL belongs to no locale and, on an install that prefixes locales, redirects — so the sitemap advertises a redirect rather than a canonical URL, and the page also gets an extra entry no locale claims.

A listener on `pages.menuitem.resolveItem` may legitimately narrow `alternateLinks`. Ours does: three storefronts share one install, each on its own host serving its own subset of locales, and a host's sitemap must not announce hreflang for another host's languages. On the storefront whose locales exclude the global default, every page ended up with a redirecting `<loc>`.

### Change

Fall back to the first alternate when the default locale is absent, so a `<loc>` is always one of the alternates:

```php
$primaryLocale = isset($itemInfo['alternateLinks'][$defaultLocale->code])
    ? $defaultLocale->code
    : array_key_first($itemInfo['alternateLinks']);
```

### Impact

Unfiltered `alternateLinks` always contain the default locale, so `$primaryLocale` is the default locale and behaviour is unchanged for a normal install. Verified on ours: the sitemap of the storefront that does serve the default locale comes out **byte-identical** before and after, hreflang ordering included, while the storefront that does not went from 115 redirecting URLs to none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sitemap generation so the primary URL is populated using the default locale when available, or an alternate locale when it is not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->